### PR TITLE
Create larger pages for large payloads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,8 @@ New experimental storage for vector payloads using mmap.
 
 ## Design
 
-- The storage is divided into pages of fixed size (32MB)
+- The storage is divided into pages of fixed minimum size (32MB), but can be larger if a single payload needs more space.
+- Each payload fits within a single page.
 - Those pages are mapped into memory using mmap
 - Those pages are following the Slotted Page structure
 - Slots are fixed size.
@@ -23,5 +24,4 @@ New experimental storage for vector payloads using mmap.
 - [ ] test update with larger data not fitting page
 - [ ] persist page tracker (as a flat vector)
 - [ ] load payload_storage from disk
-- [ ] how to handle very large payloads?
 - [ ] optimize to decrease fragmentation

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -133,7 +133,7 @@ impl PayloadStorage {
             let page = self.pages.get_mut(&page_id).unwrap();
             let mut page_guard = page.write();
             let updated = page_guard.update_value(slot_id, &comp_payload);
-            if updated.is_none() {
+            if !updated {
                 // delete slot
                 page_guard.delete_value(slot_id);
                 drop(page_guard);

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -105,14 +105,13 @@ impl PayloadStorage {
         }
     }
 
-    /// Create a new page and return its id
-    fn create_new_page(&mut self) -> u32 {
+    /// Create a new page and return its id.
+    ///
+    /// `size_hint` is used to create larger pages if necessary.
+    fn create_new_page(&mut self, size_hint: Option<usize>) -> u32 {
         let new_page_id = self.max_page_id + 1;
         let path = self.page_path(new_page_id);
-        let was_created = self.add_page(
-            new_page_id,
-            SlottedPageMmap::new(&path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES),
-        );
+        let was_created = self.add_page(new_page_id, SlottedPageMmap::new(&path, size_hint));
 
         assert!(was_created);
 
@@ -126,10 +125,6 @@ impl PayloadStorage {
 
     /// Put a payload in the storage
     pub fn put_payload(&mut self, point_offset: PointOffset, payload: Payload) {
-        if self.pages.is_empty() {
-            self.create_new_page();
-        }
-
         let payload_bytes = payload.to_bytes();
         let comp_payload = Self::compress(&payload_bytes);
         let payload_size = comp_payload.len();
@@ -148,7 +143,7 @@ impl PayloadStorage {
                     .find_best_fitting_page(payload_size)
                     .unwrap_or_else(|| {
                         // create a new page
-                        self.create_new_page()
+                        self.create_new_page(Some(payload_size))
                     });
                 let mut page = self.pages.get_mut(&new_page_id).unwrap().write();
                 let new_slot_id = page.insert_value(&comp_payload).unwrap();
@@ -164,7 +159,7 @@ impl PayloadStorage {
                 .find_best_fitting_page(payload_size)
                 .unwrap_or_else(|| {
                     // create a new page
-                    self.create_new_page()
+                    self.create_new_page(Some(payload_size))
                 });
 
             let page = self.pages.get_mut(&page_id).unwrap();
@@ -444,5 +439,44 @@ mod tests {
                 assert_eq!(stored_payload.as_ref(), model_payload);
             }
         }
+    }
+
+    #[test]
+    fn test_put_huge_payload() {
+        let (_dir, mut storage) = empty_storage();
+
+        let mut payload = Payload::default();
+        payload
+            .0
+            .insert("key".to_string(), Value::String("value".to_string()));
+
+        let huge_payload_size = 1024 * 1024 * 50; // 50MB
+
+        let distr = Uniform::new('a', 'z');
+        let rng = rand::thread_rng();
+
+        let huge_value = Value::String(distr.sample_iter(rng).take(huge_payload_size).collect());
+        payload.0.insert("huge".to_string(), huge_value);
+
+        storage.put_payload(0, payload.clone());
+        assert_eq!(storage.pages.len(), 1);
+
+        let page_mapping = storage.get_mapping(0).unwrap();
+        assert_eq!(page_mapping.page_id, 1); // first page
+        assert_eq!(page_mapping.slot_id, 0); // first slot
+
+        let stored_payload = storage.get_payload(0);
+        assert!(stored_payload.is_some());
+        assert_eq!(stored_payload.unwrap(), payload);
+
+        let page = storage.pages.get(&1).unwrap();
+
+        // the fitting page should be 64MB, so we should still have about 14MB of free space
+        let free_space = page.read().free_space();
+        assert!(
+            free_space > 1024 * 1024 * 13 && free_space < 1024 * 1024 * 15,
+            "free space should be around 14MB, but it is: {}",
+            free_space
+        );
     }
 }

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -3,19 +3,44 @@ use crate::utils_copied::mmap_ops::{
     create_and_ensure_length, open_write_mmap, transmute_from_u8, transmute_to_u8,
 };
 use memmap2::MmapMut;
+use std::cmp;
 use std::path::{Path, PathBuf};
 
 pub type SlotId = u32;
 
 #[derive(Debug, Clone)]
 struct SlottedPageHeader {
+    /// How many slots are in the page
     slot_count: u64,
+
+    /// The offset within the page where the data starts
     data_start_offset: u64,
+
+    /// 7 bytes padding for alignment
+    _align: [u8; 7],
+
+    /// The page size in bytes is 2^page_size_exp. For 32MB page, page_size_exp = 25
+    page_size_exp: u8,
 }
 
 impl SlottedPageHeader {
-    const fn size_in_bytes() -> usize {
-        8 + 8
+    fn new(required_size: usize) -> SlottedPageHeader {
+        let page_size_exp = cmp::max(SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES, required_size)
+            .next_power_of_two()
+            .trailing_zeros() as u8;
+
+        let page_size = 1 << page_size_exp;
+
+        SlottedPageHeader {
+            slot_count: 0,
+            data_start_offset: page_size,
+            page_size_exp,
+            _align: [0; 7],
+        }
+    }
+
+    fn page_size(&self) -> usize {
+        1 << self.page_size_exp
     }
 }
 
@@ -57,7 +82,7 @@ pub(crate) struct SlottedPageMmap {
 }
 
 impl SlottedPageMmap {
-    /// Slotted page is a page with a fixed size that contains slots and values.
+    /// Slotted page is a page with a minimum size that contains slots and values.
     pub const SLOTTED_PAGE_SIZE_BYTES: usize = 32 * 1024 * 1024; // 32MB
 
     /// Expect JSON values to have roughly 3–5 fields with mostly small values.
@@ -114,7 +139,7 @@ impl SlottedPageMmap {
 
     /// Write the current page header to the memory map
     fn write_page_header(&mut self) {
-        self.mmap[0..16].copy_from_slice(transmute_to_u8(&self.header));
+        self.mmap[0..size_of::<SlottedPageHeader>()].copy_from_slice(transmute_to_u8(&self.header));
     }
 
     /// Write the slot to the memory map
@@ -124,13 +149,13 @@ impl SlottedPageMmap {
     }
 
     /// Create a new page at the given path
-    pub fn new(path: &Path, page_size: usize) -> SlottedPageMmap {
+    pub fn new(path: &Path, size_hint: Option<usize>) -> SlottedPageMmap {
+        let required_size = size_hint.unwrap_or(SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let header = SlottedPageHeader::new(required_size);
+
+        let page_size = header.page_size();
         create_and_ensure_length(path, page_size).unwrap();
         let mmap = open_write_mmap(path, AdviceSetting::from(Advice::Normal)).unwrap();
-        let header = SlottedPageHeader {
-            slot_count: 0,
-            data_start_offset: page_size as u64,
-        };
         let path = path.to_path_buf();
         let mut slotted_mmap = SlottedPageMmap { path, header, mmap };
         slotted_mmap.write_page_header();
@@ -140,7 +165,8 @@ impl SlottedPageMmap {
     /// Open an existing page at the given path
     pub fn open(path: &Path) -> SlottedPageMmap {
         let mmap = open_write_mmap(path, AdviceSetting::from(Advice::Normal)).unwrap();
-        let header: &SlottedPageHeader = transmute_from_u8(&mmap[0..16]);
+        let header: &SlottedPageHeader =
+            transmute_from_u8(&mmap[0..size_of::<SlottedPageHeader>()]);
         let header = header.clone();
         let path = path.to_path_buf();
         SlottedPageMmap { path, header, mmap }
@@ -163,9 +189,9 @@ impl SlottedPageMmap {
         }
 
         let slot_offset =
-            SlottedPageHeader::size_in_bytes() + *slot_id as usize * SlotHeader::size_in_bytes();
+            size_of::<SlottedPageHeader>() + *slot_id as usize * SlotHeader::size_in_bytes();
         let start = slot_offset;
-        let end = start + SlotHeader::size_in_bytes();
+        let end = start + size_of::<SlotHeader>();
         let slot: &SlotHeader = transmute_from_u8(&self.mmap[start..end]);
         Some(slot.clone())
     }
@@ -206,10 +232,10 @@ impl SlottedPageMmap {
         let slot_count = self.header.slot_count as usize;
         if slot_count == 0 {
             // contains only the header
-            return self.mmap.len() - SlottedPageHeader::size_in_bytes();
+            return self.mmap.len() - size_of::<SlottedPageHeader>();
         }
         let last_slot_offset =
-            SlottedPageHeader::size_in_bytes() + slot_count * SlotHeader::size_in_bytes();
+            size_of::<SlottedPageHeader>() + slot_count * SlotHeader::size_in_bytes();
         let data_start_offset = self.header.data_start_offset as usize;
         data_start_offset.saturating_sub(last_slot_offset)
     }
@@ -217,7 +243,7 @@ impl SlottedPageMmap {
     /// Compute the start and end offsets for the slot
     fn offsets_for_slot(&self, slot_id: SlotId) -> (usize, usize) {
         let slot_offset =
-            SlottedPageHeader::size_in_bytes() + slot_id as usize * SlotHeader::size_in_bytes();
+            size_of::<SlottedPageHeader>() + slot_id as usize * SlotHeader::size_in_bytes();
         let start = slot_offset;
         let end = start + SlotHeader::size_in_bytes();
         (start, end)
@@ -375,14 +401,6 @@ mod tests {
     }
 
     #[test]
-    fn test_header_size() {
-        assert_eq!(
-            SlottedPageHeader::size_in_bytes(),
-            size_of::<SlottedPageHeader>()
-        );
-    }
-
-    #[test]
     fn test_slot_size() {
         assert_eq!(SlotHeader::size_in_bytes(), size_of::<SlotHeader>());
     }
@@ -397,11 +415,11 @@ mod tests {
 
         let path = file.path();
 
-        let mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mmap = SlottedPageMmap::new(path, None);
         // contains only the header
         assert_eq!(
             mmap.free_space(),
-            SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES - SlottedPageHeader::size_in_bytes()
+            SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES - size_of::<SlottedPageHeader>()
         );
         assert_eq!(mmap.header.slot_count, 0);
         assert!(mmap.get_slot(&0).is_none());
@@ -411,7 +429,7 @@ mod tests {
         let mmap = SlottedPageMmap::open(path);
         assert_eq!(
             mmap.free_space(),
-            SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES - SlottedPageHeader::size_in_bytes()
+            SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES - size_of::<SlottedPageHeader>()
         );
         assert_eq!(mmap.header.slot_count, 0);
         assert!(mmap.get_slot(&0).is_none());
@@ -426,7 +444,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mmap = SlottedPageMmap::new(path, None);
         let values = mmap.all_values();
         assert_eq!(values.len(), 0);
 
@@ -443,7 +461,7 @@ mod tests {
 
         let expected_slot_count = 220_752;
         assert_eq!(mmap.header.slot_count, expected_slot_count);
-        assert_eq!(mmap.free_space(), 112); // not enough space for a new slot + placeholder value
+        assert_eq!(mmap.free_space(), 104); // not enough space for a new slot + placeholder value
 
         // can't add more values
         assert_eq!(mmap.insert_placeholder_value(), None);
@@ -467,7 +485,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mut mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mut mmap = SlottedPageMmap::new(path, None);
         let values = mmap.all_values();
         assert_eq!(values.len(), 0);
 
@@ -477,7 +495,7 @@ mod tests {
         }
 
         assert_eq!(mmap.header.slot_count, 10);
-        assert_eq!(mmap.free_space(), 33_552_896);
+        assert_eq!(mmap.free_space(), 33_552_888);
 
         // read slots
         let slot = mmap.get_slot(&0).unwrap();
@@ -508,7 +526,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mut mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mut mmap = SlottedPageMmap::new(path, None);
         let values = mmap.all_values();
         assert_eq!(values.len(), 0);
 
@@ -522,7 +540,7 @@ mod tests {
         }
 
         assert_eq!(mmap.header.slot_count, 100);
-        assert_eq!(mmap.free_space(), 33_539_216);
+        assert_eq!(mmap.free_space(), 33_539_208);
 
         // read slots & values
         let slot = mmap.get_slot(&0).unwrap();
@@ -559,7 +577,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mut mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mut mmap = SlottedPageMmap::new(path, None);
 
         // add 100 placeholder values
         for i in 0..100 {
@@ -588,7 +606,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mut mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mut mmap = SlottedPageMmap::new(path, None);
         let values = mmap.all_values();
         assert_eq!(values.len(), 0);
 
@@ -623,7 +641,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mut mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mut mmap = SlottedPageMmap::new(path, None);
         let values = mmap.all_values();
         assert_eq!(values.len(), 0);
 
@@ -658,7 +676,7 @@ mod tests {
             .unwrap();
         let path = file.path();
 
-        let mut mmap = SlottedPageMmap::new(path, SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES);
+        let mut mmap = SlottedPageMmap::new(path, None);
         let values = mmap.all_values();
         assert_eq!(values.len(), 0);
 

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -16,31 +16,24 @@ struct SlottedPageHeader {
     /// The offset within the page where the data starts
     data_start_offset: u64,
 
-    /// 7 bytes padding for alignment
-    _align: [u8; 7],
-
-    /// The page size in bytes is 2^page_size_exp. For 32MB page, page_size_exp = 25
-    page_size_exp: u8,
+    /// The page size in bytes. Typically 32MB (33,554,432 bytes)
+    page_size: u64,
 }
 
 impl SlottedPageHeader {
     fn new(required_size: usize) -> SlottedPageHeader {
-        let page_size_exp = cmp::max(SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES, required_size)
-            .next_power_of_two()
-            .trailing_zeros() as u8;
-
-        let page_size = 1 << page_size_exp;
+        let page_size = cmp::max(SlottedPageMmap::SLOTTED_PAGE_SIZE_BYTES, required_size)
+            .next_power_of_two() as u64;
 
         SlottedPageHeader {
             slot_count: 0,
             data_start_offset: page_size,
-            page_size_exp,
-            _align: [0; 7],
+            page_size,
         }
     }
 
     fn page_size(&self) -> usize {
-        1 << self.page_size_exp
+        self.page_size as usize
     }
 }
 


### PR DESCRIPTION
We currently do not impose a limit on payload size. 

Even when http requests are cumbersome to work with if they are more than 32MB, we have endpoints which can update one field at a time. So there is a possibility for payload to be large.

With these changes, we add two things:
- page header now includes the page size. This is in the shape of 2^n, where n will typically be 25, for 32MB.
- creating a new page now requires a size hint to know if we need to create a larger-than-usual page.