### PR TITLE
Page tracker persistence

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,3 +22,4 @@ New experimental storage for vector payloads using mmap.
 ## TODOs
 
 - [ ] compaction to decrease fragmentation
+- [ ] benchmarking with realistic data payload

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,4 @@ New experimental storage for vector payloads using mmap.
 
 ## TODOs
 
-- [ ] test update with larger data not fitting page
-- [ ] persist page tracker (as a flat vector)
-- [ ] load payload_storage from disk
-- [ ] optimize to decrease fragmentation
+- [ ] compaction to decrease fragmentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod page_tracker;
 mod payload;
 mod payload_storage;
 mod slotted_page;

--- a/src/page_tracker.rs
+++ b/src/page_tracker.rs
@@ -1,0 +1,175 @@
+use crate::slotted_page::SlotId;
+use crate::utils_copied::madvise::{Advice, AdviceSetting};
+use crate::utils_copied::mmap_ops::{
+    create_and_ensure_length, open_write_mmap, transmute_from_u8, transmute_to_u8,
+};
+use memmap2::MmapMut;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub type PointOffset = u32;
+pub type PageId = u32;
+
+#[derive(Debug, Clone, Copy)]
+pub struct PagePointer {
+    pub page_id: PageId,
+    pub slot_id: SlotId,
+}
+
+impl PagePointer {
+    pub fn new(page_id: PageId, slot_id: SlotId) -> Self {
+        Self { page_id, slot_id }
+    }
+}
+
+#[derive(Default, Clone)]
+struct PageTrackerHeader {
+    count: u32,
+}
+
+pub struct PageTracker {
+    path: PathBuf,                     // path to the file
+    mapping: Vec<Option<PagePointer>>, // points_offsets are contiguous
+    header: PageTrackerHeader,         // header of the file
+    mmap: MmapMut,                     // mmap of the file
+}
+
+impl PageTracker {
+    const FILE_NAME: &'static str = "page_tracker.dat";
+    const DEFAULT_SIZE: usize = 1024 * 1024; // 1MB
+
+    /// Create a new PageTracker at the given path
+    pub fn new(path: &Path) -> Self {
+        let path = path.join(Self::FILE_NAME);
+        create_and_ensure_length(&path, Self::DEFAULT_SIZE).unwrap();
+        let mmap = open_write_mmap(&path, AdviceSetting::from(Advice::Normal)).unwrap();
+        let header = PageTrackerHeader::default();
+        let mut page_tracker = Self {
+            path,
+            mapping: Vec::new(),
+            header,
+            mmap,
+        };
+        page_tracker.write_header();
+        page_tracker
+    }
+
+    /// Open an existing PageTracker at the given path
+    /// If the file does not exist, return None
+    pub fn open(path: &Path) -> Option<Self> {
+        let path = path.join(Self::FILE_NAME);
+        if !path.exists() {
+            return None;
+        }
+        let mmap = open_write_mmap(&path, AdviceSetting::from(Advice::Normal)).unwrap();
+        let header: &PageTrackerHeader =
+            transmute_from_u8(&mmap[0..size_of::<PageTrackerHeader>()]);
+        let mut mapping = Vec::with_capacity(header.count as usize);
+        for i in 0..header.count {
+            let start_offset =
+                size_of::<PageTrackerHeader>() + i as usize * size_of::<Option<PagePointer>>();
+            let end_offset = start_offset + size_of::<Option<PagePointer>>();
+            let page_pointer: &Option<PagePointer> =
+                transmute_from_u8(&mmap[start_offset..end_offset]);
+            mapping.push(*page_pointer);
+        }
+        Some(Self {
+            path,
+            mapping,
+            header: header.clone(),
+            mmap,
+        })
+    }
+
+    pub fn all_page_ids(&self) -> HashSet<PageId> {
+        self.mapping
+            .iter()
+            .filter_map(|x| x.map(|y| y.page_id))
+            .collect()
+    }
+
+    pub fn header_len(&self) -> u32 {
+        self.header.count
+    }
+
+    /// Write the current page header to the memory map
+    fn write_header(&mut self) {
+        self.mmap[0..size_of::<PageTrackerHeader>()].copy_from_slice(transmute_to_u8(&self.header));
+    }
+
+    /// Save the mapping at the given offset
+    fn save_mapping_at(&mut self, offset: usize) {
+        let start = size_of::<PageTrackerHeader>() + offset * size_of::<Option<PagePointer>>();
+        // check if file is long enough
+        if self.mmap.len() < start + size_of::<Option<PagePointer>>() {
+            // flush the current mmap
+            self.mmap.flush().unwrap();
+            // reopen the file with a larger size (bump by DEFAULT_SIZE)
+            let new_size = self.mmap.len() + Self::DEFAULT_SIZE;
+            create_and_ensure_length(&self.path, new_size).unwrap();
+            self.mmap = open_write_mmap(&self.path, AdviceSetting::from(Advice::Normal)).unwrap();
+        }
+        let end = start + size_of::<Option<PagePointer>>();
+        self.mmap[start..end].copy_from_slice(transmute_to_u8(&self.mapping[offset]));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.mapping.is_empty()
+    }
+
+    /// Get the length of the mapping
+    /// Includes None values
+    pub fn raw_mapping_len(&self) -> usize {
+        self.mapping.len()
+    }
+
+    /// Get the length of the mapping
+    /// Excludes None values
+    pub fn mapping_len(&self) -> usize {
+        self.mapping.iter().filter(|x| x.is_some()).count()
+    }
+
+    pub fn get(&self, point_offset: u32) -> Option<&Option<PagePointer>> {
+        self.mapping.get(point_offset as usize)
+    }
+
+    fn increment_header_count(&mut self, point_offset: PointOffset) {
+        if point_offset >= self.header.count {
+            self.header.count = point_offset + 1;
+            self.write_header();
+        }
+    }
+
+    /// Set value at the given point offset
+    /// If the point offset is larger than the current length, the mapping is resized
+    pub fn set(&mut self, point_offset: u32, page_pointer: PagePointer) {
+        let point_offset = point_offset as usize;
+        // save in memory mapping vector
+        self.ensure_length(point_offset + 1);
+        self.mapping[point_offset] = Some(page_pointer);
+        // save mapping to mmap
+        self.save_mapping_at(point_offset);
+        // increment header count if necessary
+        self.increment_header_count(point_offset as u32);
+    }
+
+    pub fn clear_mapping(&mut self, point_offset: u32) {
+        let point_offset = point_offset as usize;
+        if point_offset < self.mapping.len() {
+            // clear in memory mapping vector
+            self.mapping[point_offset] = None;
+            // save mapping to mmap
+            self.save_mapping_at(point_offset);
+        }
+    }
+
+    fn resize(&mut self, new_len: usize) {
+        self.mapping.resize_with(new_len, || None);
+    }
+
+    pub fn ensure_length(&mut self, new_len: usize) {
+        if self.mapping.len() < new_len {
+            self.resize(new_len);
+        }
+    }
+}

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -1,22 +1,14 @@
+use crate::page_tracker::{PagePointer, PageTracker, PointOffset};
 use crate::payload::Payload;
-use crate::slotted_page::{SlotHeader, SlotId, SlottedPageMmap};
+use crate::slotted_page::{SlotHeader, SlottedPageMmap};
 use lz4_flex::compress_prepend_size;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-type PointOffset = u32;
-type PageId = u32;
-
-#[derive(Clone, Copy)]
-struct PagePointer {
-    page_id: PageId,
-    slot_id: SlotId,
-}
-
 pub struct PayloadStorage {
-    page_tracker: Vec<Option<PagePointer>>, // points_offsets are contiguous
+    page_tracker: PageTracker,
     pages: HashMap<u32, Arc<RwLock<SlottedPageMmap>>>, // page_id -> mmap page
     max_page_id: u32,
     base_path: PathBuf,
@@ -35,11 +27,39 @@ impl PayloadStorage {
 
     pub fn new(path: PathBuf) -> Self {
         Self {
-            page_tracker: Vec::new(),
+            page_tracker: PageTracker::new(&path),
             pages: HashMap::new(),
             max_page_id: 0,
             base_path: path,
         }
+    }
+
+    /// Open an existing PayloadStorage at the given path
+    /// Returns None if the storage does not exist
+    fn open(path: PathBuf) -> Option<Self> {
+        let page_tracker = PageTracker::open(&path)?;
+        let page_ids = page_tracker.all_page_ids();
+        // load pages
+        let mut pages = HashMap::new();
+        let mut max_page_id: u32 = 0;
+        for page_id in page_ids {
+            let page_path = &path.join(format!("slotted-paged-{}.dat", page_id));
+            if let Some(slotted_page) = SlottedPageMmap::open(page_path) {
+                let page = Arc::new(RwLock::new(slotted_page));
+                pages.insert(page_id, page);
+                if page_id > max_page_id {
+                    max_page_id = page_id;
+                }
+            } else {
+                panic!("Page not found");
+            }
+        }
+        Some(Self {
+            page_tracker,
+            pages,
+            max_page_id: 0,
+            base_path: path,
+        })
     }
 
     /// Get the path for a given page id
@@ -67,8 +87,7 @@ impl PayloadStorage {
 
     /// Get the payload for a given point offset
     pub fn get_payload(&self, point_offset: PointOffset) -> Option<Payload> {
-        let PagePointer { page_id, slot_id } =
-            self.page_tracker.get(point_offset as usize)?.as_ref()?;
+        let PagePointer { page_id, slot_id } = self.page_tracker.get(point_offset)?.as_ref()?;
         let page = self.pages.get(page_id).expect("page not found");
         let page_guard = page.read();
         let raw = page_guard.get_value(slot_id)?;
@@ -120,7 +139,7 @@ impl PayloadStorage {
 
     /// Get the mapping for a given point offset
     fn get_mapping(&self, point_offset: PointOffset) -> Option<&PagePointer> {
-        self.page_tracker.get(point_offset as usize)?.as_ref()
+        self.page_tracker.get(point_offset)?.as_ref()
     }
 
     /// Put a payload in the storage
@@ -148,10 +167,8 @@ impl PayloadStorage {
                 let mut page = self.pages.get_mut(&new_page_id).unwrap().write();
                 let new_slot_id = page.insert_value(&comp_payload).unwrap();
                 // update page_tracker
-                self.page_tracker[point_offset as usize] = Some(PagePointer {
-                    page_id: new_page_id,
-                    slot_id: new_slot_id,
-                });
+                self.page_tracker
+                    .set(point_offset, PagePointer::new(new_page_id, new_slot_id));
             }
         } else {
             // this is a new payload
@@ -165,11 +182,10 @@ impl PayloadStorage {
             let page = self.pages.get_mut(&page_id).unwrap();
             let slot_id = page.write().insert_value(&comp_payload).unwrap();
             // ensure page_tracker is long enough
-            if self.page_tracker.len() <= point_offset as usize {
-                self.page_tracker.resize(point_offset as usize + 1, None);
-            }
+            self.page_tracker.ensure_length(point_offset as usize + 1);
             // update page_tracker
-            self.page_tracker[point_offset as usize] = Some(PagePointer { page_id, slot_id });
+            self.page_tracker
+                .set(point_offset, PagePointer::new(page_id, slot_id));
         }
     }
 
@@ -181,7 +197,7 @@ impl PayloadStorage {
         // delete value from page
         page.write().delete_value(slot_id);
         // delete mapping
-        self.page_tracker[point_offset as usize] = None;
+        self.page_tracker.clear_mapping(point_offset);
         Some(())
     }
 }
@@ -257,7 +273,7 @@ mod tests {
         let payload = Payload::default();
         storage.put_payload(0, payload);
         assert_eq!(storage.pages.len(), 1);
-        assert_eq!(storage.page_tracker.len(), 1);
+        assert_eq!(storage.page_tracker.raw_mapping_len(), 1);
 
         let stored_payload = storage.get_payload(0);
         assert!(stored_payload.is_some());
@@ -275,7 +291,7 @@ mod tests {
 
         storage.put_payload(0, payload.clone());
         assert_eq!(storage.pages.len(), 1);
-        assert_eq!(storage.page_tracker.len(), 1);
+        assert_eq!(storage.page_tracker.raw_mapping_len(), 1);
 
         let page_mapping = storage.get_mapping(0).unwrap();
         assert_eq!(page_mapping.page_id, 1); // first page
@@ -353,7 +369,7 @@ mod tests {
 
         storage.put_payload(0, payload.clone());
         assert_eq!(storage.pages.len(), 1);
-        assert_eq!(storage.page_tracker.len(), 1);
+        assert_eq!(storage.page_tracker.raw_mapping_len(), 1);
 
         let page_mapping = storage.get_mapping(0).unwrap();
         assert_eq!(page_mapping.page_id, 1); // first page
@@ -371,7 +387,7 @@ mod tests {
 
         storage.put_payload(0, updated_payload.clone());
         assert_eq!(storage.pages.len(), 1);
-        assert_eq!(storage.page_tracker.len(), 1);
+        assert_eq!(storage.page_tracker.raw_mapping_len(), 1);
 
         let stored_payload = storage.get_payload(0);
         assert!(stored_payload.is_some());
@@ -405,17 +421,18 @@ mod tests {
 
     #[test]
     fn test_behave_like_hashmap() {
-        let (_dir, mut storage) = empty_storage();
+        let (dir, mut storage) = empty_storage();
 
         let rng = &mut rand::thread_rng();
         let max_point_offset = 100000u32;
 
         let mut model_hashmap = HashMap::new();
 
-        let operations = (0..1000u32)
+        let operations = (0..10000u32)
             .map(|_| Operation::random(rng, max_point_offset))
             .collect::<Vec<_>>();
 
+        // apply operations to storage and model_hashmap
         for operation in operations.iter() {
             match operation {
                 Operation::Put(point_offset, payload) => {
@@ -431,13 +448,37 @@ mod tests {
                     model_hashmap.insert(*point_offset, payload.clone());
                 }
             }
+        }
 
-            // validate storage and model_hashmap are the same
-            for point_offset in 0..=max_point_offset {
-                let stored_payload = storage.get_payload(point_offset);
-                let model_payload = model_hashmap.get(&point_offset);
-                assert_eq!(stored_payload.as_ref(), model_payload);
-            }
+        // asset same length
+        assert_eq!(storage.page_tracker.mapping_len(), model_hashmap.len());
+
+        // validate storage and model_hashmap are the same
+        for point_offset in 0..=max_point_offset {
+            let stored_payload = storage.get_payload(point_offset);
+            let model_payload = model_hashmap.get(&point_offset);
+            assert_eq!(stored_payload.as_ref(), model_payload);
+        }
+
+        // drop storage
+        drop(storage);
+
+        // reopen storage
+        let storage = PayloadStorage::open(dir.path().to_path_buf()).unwrap();
+
+        // asset same length
+        assert_eq!(storage.page_tracker.mapping_len(), model_hashmap.len());
+
+        // validate storage and model_hashmap are the same
+        for point_offset in 0..=max_point_offset {
+            let stored_payload = storage.get_payload(point_offset);
+            let model_payload = model_hashmap.get(&point_offset);
+            assert_eq!(
+                stored_payload.as_ref(),
+                model_payload,
+                "failed for point_offset: {}",
+                point_offset
+            );
         }
     }
 
@@ -478,5 +519,42 @@ mod tests {
             "free space should be around 14MB, but it is: {}",
             free_space
         );
+    }
+
+    #[test]
+    fn test_storage_persistence_basic() {
+        let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+
+        let mut payload = Payload::default();
+        payload
+            .0
+            .insert("key".to_string(), Value::String("value".to_string()));
+
+        {
+            let mut storage = PayloadStorage::new(path.clone());
+
+            storage.put_payload(0, payload.clone());
+            assert_eq!(storage.pages.len(), 1);
+
+            let page_mapping = storage.get_mapping(0).unwrap();
+            assert_eq!(page_mapping.page_id, 1); // first page
+            assert_eq!(page_mapping.slot_id, 0); // first slot
+
+            let stored_payload = storage.get_payload(0);
+            assert!(stored_payload.is_some());
+            assert_eq!(stored_payload.unwrap(), payload);
+
+            // drop storage
+            drop(storage);
+        }
+
+        // reopen storage
+        let storage = PayloadStorage::open(path.clone()).unwrap();
+        assert_eq!(storage.pages.len(), 1);
+
+        let stored_payload = storage.get_payload(0);
+        assert!(stored_payload.is_some());
+        assert_eq!(stored_payload.unwrap(), payload);
     }
 }

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -27,7 +27,7 @@ impl PayloadStorage {
 
     pub fn new(path: PathBuf) -> Self {
         Self {
-            page_tracker: PageTracker::new(&path),
+            page_tracker: PageTracker::new(&path, None),
             pages: HashMap::new(),
             max_page_id: 0,
             base_path: path,
@@ -181,8 +181,6 @@ impl PayloadStorage {
 
             let page = self.pages.get_mut(&page_id).unwrap();
             let slot_id = page.write().insert_value(&comp_payload).unwrap();
-            // ensure page_tracker is long enough
-            self.page_tracker.ensure_length(point_offset as usize + 1);
             // update page_tracker
             self.page_tracker
                 .set(point_offset, PagePointer::new(page_id, slot_id));

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -87,7 +87,7 @@ impl PayloadStorage {
 
     /// Get the payload for a given point offset
     pub fn get_payload(&self, point_offset: PointOffset) -> Option<Payload> {
-        let PagePointer { page_id, slot_id } = self.page_tracker.get(point_offset)?.as_ref()?;
+        let PagePointer { page_id, slot_id } = self.get_mapping(point_offset)?;
         let page = self.pages.get(page_id).expect("page not found");
         let page_guard = page.read();
         let raw = page_guard.get_value(slot_id)?;
@@ -139,7 +139,7 @@ impl PayloadStorage {
 
     /// Get the mapping for a given point offset
     fn get_mapping(&self, point_offset: PointOffset) -> Option<&PagePointer> {
-        self.page_tracker.get(point_offset)?.as_ref()
+        self.page_tracker.get(point_offset)
     }
 
     /// Put a payload in the storage


### PR DESCRIPTION
Adds full persistence for the page tracker.

Enables to reopen a payload storage from disk.