### PR TITLE
Compaction for fragmented pages

### DIFF
--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -718,7 +718,10 @@ mod tests {
         assert_eq!(point_offset, EXPECTED_LEN as u32 * 2);
         assert_eq!(storage.pages.len(), 3);
         assert_eq!(storage.page_tracker.read().mapping_len(), EXPECTED_LEN * 2);
-        assert_eq!(storage.page_tracker.read().raw_mapping_len(), EXPECTED_LEN * 2);
+        assert_eq!(
+            storage.page_tracker.read().raw_mapping_len(),
+            EXPECTED_LEN * 2
+        );
 
         // assert storage is consistent
         storage_double_pass_is_consistent(&storage);
@@ -732,7 +735,7 @@ mod tests {
         // assert storage is consistent after reopening
         storage_double_pass_is_consistent(&storage);
     }
-    
+
     #[test]
     fn test_compaction() {
         let (_dir, mut storage) = empty_storage();
@@ -743,22 +746,22 @@ mod tests {
         let large_payloads = (0..max_point_offset)
             .map(|_| one_random_payload_please(rng, 10))
             .collect::<Vec<_>>();
-        
+
         for i in 0..max_point_offset {
             storage.put_payload(i as u32, large_payloads[i].clone());
         }
-        
+
         // sanity check
         for i in 0..max_point_offset {
             let stored_payload = storage.get_payload(i as u32);
             assert_eq!(stored_payload.as_ref(), Some(&large_payloads[i]));
         }
-        
+
         // check no fragmentation
         for page in storage.pages.values() {
             assert_eq!(page.read().fragmented_space(), 0);
         }
-        
+
         // update with smaller values
         let small_payloads = (0..max_point_offset)
             .map(|_| one_random_payload_please(rng, 1))
@@ -766,25 +769,25 @@ mod tests {
         for i in 0..max_point_offset {
             storage.put_payload(i as u32, small_payloads[i].clone());
         }
-        
+
         // sanity check
         for i in 0..max_point_offset {
             let stored_payload = storage.get_payload(i as u32);
             assert_eq!(stored_payload.as_ref(), Some(&small_payloads[i]));
         }
-        
+
         // check fragmentation
         assert!(!storage.pages_to_defrag().is_empty());
-        
+
         // compaction
         storage.compact();
-        
+
         // check consistency
         for i in 0..max_point_offset {
             let stored_payload = storage.get_payload(i as u32);
             assert_eq!(stored_payload.as_ref(), Some(&small_payloads[i]));
         }
-        
+
         // check no outstanding fragmentation
         assert!(storage.pages_to_defrag().is_empty());
     }

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -826,7 +826,7 @@ mod tests {
         let small_payloads = (0..max_point_offset)
             .map(|_| one_random_payload_please(rng, 1))
             .collect::<Vec<_>>();
-        
+
         for (i, payload) in small_payloads.iter().enumerate() {
             storage.put_payload(i as u32, payload.clone());
         }

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -277,7 +277,7 @@ impl SlottedPageMmap {
         let mut fragmented_space = 0;
 
         let mut slot_id = 0;
-        let mut last_offset = 0u64;
+        let mut last_offset = self.page_size() as u64;
         while let Some(slot) = self.get_slot_ref(&slot_id) {
             // if the slot is deleted, we can consider it empty space
             if slot.deleted {

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -123,8 +123,8 @@ impl SlottedPageMmap {
     pub fn iter_slot_values_starting_from(
         &self,
         slot_id: SlotId,
-    ) -> impl Iterator<Item = (&SlotHeader, Option<&[u8]>)> + '_ {
-        if slot_id as u64 >= self.header.slot_count {
+    ) -> impl Iterator<Item = (&SlotHeader, Option<&[u8]>)> + '_ {        
+        if slot_id as u64 >= self.header.slot_count && self.header.slot_count > 0 {
             panic!("Slot id out of bounds")
         }
 

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -111,6 +111,7 @@ impl SlottedPageMmap {
     }
 
     /// Return all values in the page with placeholder or deleted values as `None`
+    #[cfg(test)]
     pub fn all_values(&self) -> Vec<Option<&[u8]>> {
         self.iter_slot_values_starting_from(0)
             .map(|(_, value)| value)
@@ -141,6 +142,7 @@ impl SlottedPageMmap {
     }
 
     /// Returns all non deleted values in the page. `None` values means that the slot is a placeholder
+    #[cfg(test)]
     fn non_deleted_values(&self) -> Vec<&[u8]> {
         let mut values = Vec::new();
         for i in 0..self.header.slot_count {
@@ -242,6 +244,7 @@ impl SlottedPageMmap {
     }
 
     /// Check if there is enough space for a new slot + min value
+    #[cfg(test)]
     fn has_capacity_for_min_value(&self) -> bool {
         self.free_space()
             .saturating_sub(SlotHeader::size_in_bytes() + SlottedPageMmap::MIN_VALUE_SIZE_BYTES)
@@ -432,7 +435,7 @@ impl SlottedPageMmap {
     }
 
     /// Delete the page from the filesystem.
-    pub fn drop_page(self) {
+    pub fn delete_page(self) {
         drop(self.mmap);
         std::fs::remove_file(&self.path).unwrap();
     }

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -123,7 +123,7 @@ impl SlottedPageMmap {
     pub fn iter_slot_values_starting_from(
         &self,
         slot_id: SlotId,
-    ) -> impl Iterator<Item = (&SlotHeader, Option<&[u8]>)> + '_ {        
+    ) -> impl Iterator<Item = (&SlotHeader, Option<&[u8]>)> + '_ {
         if slot_id as u64 >= self.header.slot_count && self.header.slot_count > 0 {
             panic!("Slot id out of bounds")
         }

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -41,29 +41,45 @@ impl SlottedPageHeader {
 pub struct SlotHeader {
     offset: u64,       // offset in the page (8 bytes)
     length: u64,       // length of the value (8 bytes)
+    point_offset: u32, // point id (4 bytes)
     right_padding: u8, // padding within the value for small values (1 byte)
     deleted: bool,     // whether the value has been deleted (1 byte)
-    _align: [u8; 6],   // 6 bytes padding for alignment
+    _align: [u8; 2],   // 2 bytes padding for alignment
 }
 
 impl SlotHeader {
     pub const fn size_in_bytes() -> usize {
         size_of::<Self>()
-        // 24 // 8 + 8 + 1 + 1 + 6 padding
+        // 24 // 8 + 8 + 4 + 1 + 1 + 2 padding
     }
 
-    fn new(offset: u64, length: u64, right_padding: u8, deleted: bool) -> SlotHeader {
+    fn new(
+        point_offset: u32,
+        offset: u64,
+        length: u64,
+        right_padding: u8,
+        deleted: bool,
+    ) -> SlotHeader {
         assert!(
             length >= SlottedPageMmap::MIN_VALUE_SIZE_BYTES as u64,
             "Value too small"
         );
         SlotHeader {
+            point_offset,
             offset,
             length,
             right_padding,
             deleted,
-            _align: [0; 6],
+            _align: [0; 2],
         }
+    }
+
+    pub fn point_offset(&self) -> u32 {
+        self.point_offset
+    }
+
+    pub fn deleted(&self) -> bool {
+        self.deleted
     }
 }
 
@@ -87,33 +103,45 @@ impl SlottedPageMmap {
     const PLACEHOLDER_VALUE: [u8; SlottedPageMmap::MIN_VALUE_SIZE_BYTES] =
         [0; SlottedPageMmap::MIN_VALUE_SIZE_BYTES];
 
+    pub const FRAGMENTATION_THRESHOLD_RATIO: f32 = 0.5;
+
     /// Flushes outstanding memory map modifications to disk.
     fn flush(&self) {
         self.mmap.flush().unwrap();
     }
 
-    /// Return all values in the page with deleted values as None
-    fn all_values(&self) -> Vec<Option<&[u8]>> {
-        let mut values = Vec::new();
-        for i in 0..self.header.slot_count {
-            let slot = self.get_slot(&(i as u32)).unwrap();
-            // skip values associated with deleted slots
-            if slot.deleted {
-                values.push(None);
-                continue;
-            }
-            match self.get_slot_value(&slot) {
-                Some(value) => values.push(Some(value)),
-                None => values.push(None),
-            }
-        }
-        // values are stored in reverse order
-        values.reverse();
-        values
+    /// Return all values in the page with placeholder or deleted values as `None`
+    pub fn all_values(&self) -> Vec<Option<&[u8]>> {
+        self.iter_slot_values_starting_from(0)
+            .map(|(_, value)| value)
+            .collect()
     }
 
-    /// Returns all non deleted values in the page
-    fn values(&self) -> Vec<&[u8]> {
+    /// Iterate over all values in the page, starting at the provided slot id.
+    ///
+    /// `None` values can be either placeholders, or deleted values
+    pub fn iter_slot_values_starting_from(
+        &self,
+        slot_id: SlotId,
+    ) -> impl Iterator<Item = (&SlotHeader, Option<&[u8]>)> + '_ {
+        if slot_id as u64 >= self.header.slot_count {
+            panic!("Slot id out of bounds")
+        }
+
+        (slot_id as u64..self.header.slot_count).map(move |i| {
+            let slot = self.get_slot_ref(&(i as u32)).unwrap();
+            let value = if slot.deleted {
+                None
+            } else {
+                self.get_slot_value(slot)
+            };
+
+            (slot, value)
+        })
+    }
+
+    /// Returns all non deleted values in the page. `None` values means that the slot is a placeholder
+    fn non_deleted_values(&self) -> Vec<&[u8]> {
         let mut values = Vec::new();
         for i in 0..self.header.slot_count {
             let slot = self.get_slot(&(i as u32)).unwrap();
@@ -125,8 +153,6 @@ impl SlottedPageMmap {
                 values.push(value)
             }
         }
-        // values are stored in reverse order
-        values.reverse();
         values
     }
 
@@ -180,6 +206,10 @@ impl SlottedPageMmap {
 
     /// Get the slot associated with the slot id.
     fn get_slot(&self, slot_id: &u32) -> Option<SlotHeader> {
+        self.get_slot_ref(slot_id).cloned()
+    }
+
+    fn get_slot_ref(&self, slot_id: &SlotId) -> Option<&SlotHeader> {
         let slot_count = self.header.slot_count;
         if *slot_id >= slot_count as u32 {
             return None;
@@ -190,7 +220,8 @@ impl SlottedPageMmap {
         let start = slot_offset;
         let end = start + size_of::<SlotHeader>();
         let slot: &SlotHeader = transmute_from_u8(&self.mmap[start..end]);
-        Some(slot.clone())
+
+        Some(slot)
     }
 
     /// Get value associated with the slot
@@ -237,6 +268,35 @@ impl SlottedPageMmap {
         data_start_offset.saturating_sub(last_slot_offset)
     }
 
+    pub fn page_size(&self) -> usize {
+        self.header.page_size()
+    }
+
+    /// Sums the amount of unused space in between the data.
+    pub fn fragmented_space(&self) -> usize {
+        let mut fragmented_space = 0;
+
+        let mut slot_id = 0;
+        let mut last_offset = 0u64;
+        while let Some(slot) = self.get_slot_ref(&slot_id) {
+            // if the slot is deleted, we can consider it empty space
+            if slot.deleted {
+                fragmented_space += slot.length;
+            }
+
+            // check the empty space between the last slot and the end of the current slot
+            fragmented_space += last_offset
+                .checked_sub(slot.offset + slot.length)
+                .expect("last_offset should be to the right of the current slot end");
+
+            // update for next iteration
+            last_offset = slot.offset;
+            slot_id += 1;
+        }
+
+        fragmented_space as usize
+    }
+
     /// Compute the start and end offsets for the slot
     fn offsets_for_slot(&self, slot_id: SlotId) -> (usize, usize) {
         let slot_offset =
@@ -247,8 +307,8 @@ impl SlottedPageMmap {
     }
 
     /// Insert a new placeholder into the page
-    pub fn insert_placeholder_value(&mut self) -> Option<SlotId> {
-        self.insert_value(&SlottedPageMmap::PLACEHOLDER_VALUE)
+    pub fn insert_placeholder_value(&mut self, point_id: u32) -> Option<SlotId> {
+        self.insert_value(point_id, &SlottedPageMmap::PLACEHOLDER_VALUE)
     }
 
     /// Insert a new value into the page
@@ -256,7 +316,7 @@ impl SlottedPageMmap {
     /// Returns
     /// - None if there is not enough space for a new slot + value
     /// - Some(slot_id) if the value was successfully added
-    pub fn insert_value(&mut self, value: &[u8]) -> Option<SlotId> {
+    pub fn insert_value(&mut self, point_offset: u32, value: &[u8]) -> Option<SlotId> {
         // size of the value in bytes
         let real_value_size = value.len();
 
@@ -278,6 +338,7 @@ impl SlottedPageMmap {
         let slot_count = self.header.slot_count;
         let next_slot_id = slot_count as SlotId;
         let slot = SlotHeader::new(
+            point_offset,
             new_data_start_offset as u64,
             value_len as u64,
             padding as u8,
@@ -357,6 +418,7 @@ impl SlottedPageMmap {
         // actual value size accounting for the minimum value size
         let value_len = real_value_size + right_padding;
         let update_slot = SlotHeader::new(
+            slot.point_offset,
             value_start as u64,  // new offset value
             value_len as u64,    // new value size
             right_padding as u8, // new padding
@@ -367,6 +429,12 @@ impl SlottedPageMmap {
         self.write_slot(slot_id, update_slot);
 
         true
+    }
+
+    /// Delete the page from the filesystem.
+    pub fn drop_page(self) {
+        drop(self.mmap);
+        std::fs::remove_file(&self.path).unwrap();
     }
 
     // TODO
@@ -455,9 +523,11 @@ mod tests {
         let mut mmap = SlottedPageMmap::open(path).unwrap();
 
         let mut free_space = mmap.free_space();
+        let mut sequence = 0u32..;
         // add placeholder values
         while mmap.has_capacity_for_min_value() {
-            mmap.insert_placeholder_value().unwrap();
+            mmap.insert_placeholder_value(sequence.next().unwrap())
+                .unwrap();
             let new_free_space = mmap.free_space();
             assert!(new_free_space < free_space);
             free_space = new_free_space;
@@ -468,7 +538,10 @@ mod tests {
         assert_eq!(mmap.free_space(), 104); // not enough space for a new slot + placeholder value
 
         // can't add more values
-        assert_eq!(mmap.insert_placeholder_value(), None);
+        assert_eq!(
+            mmap.insert_placeholder_value(sequence.next().unwrap()),
+            None
+        );
 
         // drop and reopen
         drop(mmap);
@@ -477,7 +550,7 @@ mod tests {
         assert_eq!(mmap.header.data_start_offset, 5_298_176);
 
         assert_eq!(mmap.all_values().len(), expected_slot_count as usize);
-        assert_eq!(mmap.values().len(), 0);
+        assert_eq!(mmap.non_deleted_values().len(), 0);
     }
 
     #[test]
@@ -494,8 +567,8 @@ mod tests {
         assert_eq!(values.len(), 0);
 
         // add 10 placeholder values
-        for _ in 0..10 {
-            mmap.insert_placeholder_value().unwrap();
+        for i in 0..10 {
+            mmap.insert_placeholder_value(i).unwrap();
         }
 
         assert_eq!(mmap.header.slot_count, 10);
@@ -540,7 +613,8 @@ mod tests {
                 bar: i,
                 qux: i % 2 == 0,
             };
-            mmap.insert_value(foo.to_bytes().as_slice()).unwrap();
+            mmap.insert_value(i as u32, foo.to_bytes().as_slice())
+                .unwrap();
         }
 
         assert_eq!(mmap.header.slot_count, 100);
@@ -589,7 +663,8 @@ mod tests {
                 bar: i,
                 qux: i % 2 == 0,
             };
-            mmap.insert_value(foo.to_bytes().as_slice()).unwrap();
+            mmap.insert_value(i as u32, foo.to_bytes().as_slice())
+                .unwrap();
         }
 
         // delete slot 10
@@ -598,7 +673,7 @@ mod tests {
         assert!(mmap.get_slot(&10).unwrap().deleted);
 
         assert_eq!(mmap.all_values().len(), 100);
-        assert_eq!(mmap.values().len(), 99)
+        assert_eq!(mmap.non_deleted_values().len(), 99)
     }
 
     #[test]
@@ -616,7 +691,7 @@ mod tests {
 
         // push one value
         let foo = Foo { bar: 1, qux: true };
-        mmap.insert_value(foo.to_bytes().as_slice()).unwrap();
+        mmap.insert_value(0, foo.to_bytes().as_slice()).unwrap();
 
         // read slots & values
         let slot = mmap.get_slot(&0).unwrap();
@@ -651,7 +726,7 @@ mod tests {
         assert_eq!(values.len(), 0);
 
         // push placeholder value
-        mmap.insert_placeholder_value().unwrap();
+        mmap.insert_placeholder_value(0).unwrap();
         let values = mmap.all_values();
         assert_eq!(values.len(), 1);
         assert_eq!(mmap.get_value(&0), None);
@@ -687,7 +762,7 @@ mod tests {
         assert_eq!(values.len(), 0);
 
         // push placeholder value
-        mmap.insert_placeholder_value().unwrap();
+        mmap.insert_placeholder_value(0).unwrap();
         let values = mmap.all_values();
         assert_eq!(values.len(), 1);
         assert_eq!(mmap.get_value(&0), None);


### PR DESCRIPTION
After a while, we expect that having enough updates will create unused regions in between the data for the values, which will be wasted space. 

With these changes we add the ability to trigger a compaction. It:
- Detects which pages are over some threshold of fragmentation
- Copies all values in these pages into new pages sequentially, so that the new pages will have perfectly contiguous data.
- Introduces the point id into the slot, so that we can update the page_tracker easily.
- Updates the page_tracker with the new pointer to the slot in the new page.
- Deletes the fragmented pages.