### PR TITLE
Add criterion benchmarking infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ Cargo.lock
 
 mutants.out/
 mutants.out.old/
+
+# perf
+perf.data
+perf.data.old
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ tempfile = "3.12.0"
 serde_cbor = "0.11.2"
 lz4_flex = { version = "0.11", default-features = false }
 rand = "0.8.5"
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "storage_bench"
+harness = false

--- a/benches/storage_bench.rs
+++ b/benches/storage_bench.rs
@@ -1,0 +1,22 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use mmap_payload_storage::fixtures::{empty_storage, one_random_payload_please};
+
+const PAYLOAD_COUNT: usize = 10_000;
+
+pub fn storage_bench(c: &mut Criterion) {
+    let (_dir, mut storage) = empty_storage();
+    let mut rng = rand::thread_rng();
+    c.bench_function("write/read payload", |b| {
+        let payload = one_random_payload_please(&mut rng, 1);
+        b.iter(|| {
+            for i in 0..PAYLOAD_COUNT {
+                storage.put_payload(i as u32, payload.clone());
+                let res = storage.get_payload(i as u32);
+                assert!(res.is_some());
+            }
+        });
+    });
+}
+
+criterion_group!(benches, storage_bench);
+criterion_main!(benches);

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -1,0 +1,51 @@
+use crate::payload::Payload;
+use crate::PayloadStorage;
+use rand::distributions::{Distribution, Uniform};
+use rand::Rng;
+use tempfile::{Builder, TempDir};
+
+pub fn empty_storage() -> (TempDir, PayloadStorage) {
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let storage = PayloadStorage::new(dir.path().to_path_buf());
+    assert!(storage.is_empty());
+    (dir, storage)
+}
+
+pub fn random_word(rng: &mut impl Rng) -> String {
+    let len = rng.gen_range(1..10);
+    let mut word = String::with_capacity(len);
+    for _ in 0..len {
+        word.push(rng.gen_range(b'a'..=b'z') as char);
+    }
+    word
+}
+
+pub fn one_random_payload_please(rng: &mut impl Rng, size_factor: usize) -> Payload {
+    let mut payload = Payload::default();
+
+    let word = random_word(rng);
+
+    let sentence = (0..rng.gen_range(1..20 * size_factor))
+        .map(|_| random_word(rng))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let distr = Uniform::new(0, 100000);
+    let indices = (0..rng.gen_range(1..100 * size_factor))
+        .map(|_| distr.sample(rng))
+        .collect::<Vec<_>>();
+
+    payload.0 = serde_json::json!(
+        {
+            "word": word, // string
+            "sentence": sentence, // string
+            "number": rng.gen_range(0..1000), // number
+            "indices": indices // array of numbers
+        }
+    )
+    .as_object()
+    .unwrap()
+    .clone();
+
+    payload
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod fixtures;
 mod page_tracker;
 mod payload;
 mod payload_storage;

--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -59,6 +59,10 @@ impl PayloadStorage {
         })
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.pages.is_empty() && self.page_tracker.is_empty()
+    }
+
     /// Get the path for a given page id
     pub fn page_path(&self, page_id: u32) -> PathBuf {
         self.base_path
@@ -201,58 +205,10 @@ impl PayloadStorage {
 mod tests {
     use super::*;
     use serde_json::Value;
-    use tempfile::{Builder, TempDir};
 
+    use crate::fixtures::{empty_storage, one_random_payload_please};
     use rand::{distributions::Uniform, prelude::Distribution, seq::SliceRandom, Rng};
-
-    fn empty_storage() -> (TempDir, PayloadStorage) {
-        let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
-        let storage = PayloadStorage::new(dir.path().to_path_buf());
-
-        assert!(storage.pages.is_empty());
-        assert!(storage.page_tracker.is_empty());
-
-        (dir, storage)
-    }
-
-    fn random_word(rng: &mut impl Rng) -> String {
-        let len = rng.gen_range(1..10);
-        let mut word = String::with_capacity(len);
-        for _ in 0..len {
-            word.push(rng.gen_range(b'a'..=b'z') as char);
-        }
-        word
-    }
-
-    fn one_random_payload_please(rng: &mut impl Rng, size_factor: usize) -> Payload {
-        let mut payload = Payload::default();
-
-        let word = random_word(rng);
-
-        let sentence = (0..rng.gen_range(1..20 * size_factor))
-            .map(|_| random_word(rng))
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        let distr = Uniform::new(0, 100000);
-        let indices = (0..rng.gen_range(1..100 * size_factor))
-            .map(|_| distr.sample(rng))
-            .collect::<Vec<_>>();
-
-        payload.0 = serde_json::json!(
-            {
-                "word": word, // string
-                "sentence": sentence, // string
-                "number": rng.gen_range(0..1000), // number
-                "indices": indices // array of numbers
-            }
-        )
-        .as_object()
-        .unwrap()
-        .clone();
-
-        payload
-    }
+    use tempfile::Builder;
 
     #[test]
     fn test_empty_payload_storage() {


### PR DESCRIPTION
This PR adds a basic criterion benchmark to get us started.

I moved some test helpers into a dedicated fixtures files to get access from benchmarks.

![bench-storage](https://github.com/user-attachments/assets/8daf3871-80cc-421f-b565-980e387609de)
