### PR TITLE
Test with realistic data from H&M article dataset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.8.5"
 
 [dev-dependencies]
 criterion = "0.5.1"
+csv = "1.3.0"
 
 [[bench]]
 name = "storage_bench"

--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,23 @@ New experimental storage for vector payloads using mmap.
 ## TODOs
 
 - [ ] compaction to decrease fragmentation
-- [ ] benchmarking with realistic data payload
+- [ ] benchmarking with realistic data payload (CPU + memory usage)
+- [ ] run unit tests different page sizes
+- [ ] test best fitting page logic
+- [ ] test data consistency on panic
+- [ ] dictionary compression to optimize payload key repetition
+- [ ] validate the usage with a block storage via HTTP range requests
+- [ ] handle all surviving mutants
+  - MISSED   src/page_tracker.rs:117:44: replace + with * in PageTracker::persist_pointer in 0.6s build + 29.6s test
+  - MISSED   src/slotted_page.rs:352:26: replace > with == in SlottedPageMmap::update_value in 0.5s build + 29.8s test
+  - MISSED   src/payload_storage.rs:50:24: replace > with < in PayloadStorage::open in 0.5s build + 29.6s test
+  - MISSED   src/payload_storage.rs:107:69: replace + with - in PayloadStorage::find_best_fitting_page in 0.9s build + 29.9s test
+  - MISSED   src/payload_storage.rs:103:9: replace PayloadStorage::find_best_fitting_page -> Option<u32> with None in 0.6s build + 60.0s test
+  - MISSED   src/payload_storage.rs:107:69: replace + with * in PayloadStorage::find_best_fitting_page in 0.5s build + 30.5s test
+  - MISSED   src/payload_storage.rs:63:9: replace PayloadStorage::is_empty -> bool with true in 0.5s build + 29.5s test
+  - MISSED   src/payload_storage.rs:63:31: replace && with || in PayloadStorage::is_empty in 0.9s build + 30.5s test
+  - MISSED   src/page_tracker.rs:113:36: replace + with * in PageTracker::persist_pointer in 0.9s build + 30.4s test
+  - MISSED   src/slotted_page.rs:293:20: replace > with < in SlottedPageMmap::insert_value in 0.5s build + 29.4s test
+  - MISSED   src/slotted_page.rs:352:26: replace > with < in SlottedPageMmap::update_value in 0.4s build + 28.8s test
+  - MISSED   src/slotted_page.rs:92:9: replace SlottedPageMmap::flush with () in 0.4s build + 28.6s test
+  - MISSED   src/slotted_page.rs:293:20: replace > with == in SlottedPageMmap::insert_value in 0.5s build + 29.0s test


### PR DESCRIPTION
This PR introduces a test using a realistic dataset from H&M. (see [articles.csv](https://www.kaggle.com/c/h-and-m-personalized-fashion-recommendations)) 

The dataset weights around 30MB and is included in the repository for convenience.

The unit test loads the CSV and creates one payload per row extracting all field.

The CSV is loaded twice in the storage to generate load and to be able to validate data consistency.