### PR TITLE
Reuse deleted slots when possible

### DIFF
--- a/src/payload_storage.rs
+++ b/src/payload_storage.rs
@@ -121,9 +121,10 @@ impl PayloadStorage {
 
         if let Some((page_id, _deleted_slots_count)) = self.pages_by_deleted_slots.peek() {
             if let Some(page) = self.pages.get(page_id) {
-                let slot = page.largest_deleted_slot();
-                if slot.length >= needed_size as u64 {
-                    return Some(*page_id);
+                if let Some(slot) = page.largest_deleted_slot() {
+                    if slot.length >= needed_size as u64 {
+                        return Some(*page_id);
+                    }
                 }
             }
         }

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -536,7 +536,7 @@ impl SlottedPageMmap {
         if current_slot.deleted {
             return None;
         }
-        
+
         // mark slot as deleted
         let updated_slot = SlotHeader {
             deleted: true,
@@ -1035,7 +1035,6 @@ mod tests {
 
         let mut page = SlottedPageMmap::new(path, TEST_PAGE_SIZE);
 
-        
         // insert two values with different sizes
         let foo = Foo { bar: 1, qux: true }.to_bytes();
         let (slot_id, _) = page.insert_value(0, &foo).unwrap();
@@ -1046,7 +1045,6 @@ mod tests {
         assert_eq!(retrieved_value, foo);
         let retrieved_value_large = page.get_value(&slot_id_large).unwrap();
         assert_eq!(retrieved_value_large, &foo_large);
-        
 
         page.delete_value(slot_id_large);
         page.delete_value(slot_id);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -23,7 +23,7 @@ impl PayloadStorage {
         let pages_count = self.pages.len();
         let default_page_bytes = self.new_page_size;
         let available_bytes = self
-            .page_emptiness
+            .pages_by_free_space
             .iter()
             .map(|(_, &free_space)| free_space)
             .sum();


### PR DESCRIPTION
Enables the storage to try to reuse deleted slots for new payloads. So that we mitigate fragmentation.

- Adds a priority queue of pages by amount of deleted slots.
- Stores the amount of deleted slots in the header of each page.
- Once the page is selected, it does a linear scan to find the largest deleted slot.

### Possible improvements
- [x] Add a priority queue for each page to track slot_id to their size, so that finding the largest is quicker.
- [ ] Use a cuckoo filter (like a bloom filter but supports deletions) for deleted slots, so that we don't have to read the headers to know whether a slot is deleted.