### PR TITLE
Migrate to Ciborium

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0.210", features = ["derive"] }
 parking_lot = "0.12.3"
 log = "0.4.22"
 tempfile = "3.13.0"
-serde_cbor = "0.11.2"
+ciborium = "0.2.2"
 lz4_flex = { version = "0.11.3", default-features = false }
 rand = "0.8.5"
 priority-queue = "2.1.1"

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -12,11 +12,13 @@ impl Default for Payload {
 
 impl Payload {
     pub fn to_bytes(&self) -> Vec<u8> {
-        serde_cbor::to_vec(self).unwrap()
+        let mut vec = Vec::new();
+        ciborium::ser::into_writer(self, &mut vec).unwrap();
+        vec
     }
 
     pub fn from_bytes(data: &[u8]) -> Self {
-        serde_cbor::from_slice(data).unwrap()
+        ciborium::de::from_reader(data).unwrap()
     }
 }
 

--- a/src/slotted_page.rs
+++ b/src/slotted_page.rs
@@ -479,11 +479,13 @@ mod tests {
 
     impl Foo {
         pub fn to_bytes(&self) -> Vec<u8> {
-            serde_cbor::to_vec(self).unwrap()
+            let mut vec = Vec::new();
+            ciborium::ser::into_writer(self, &mut vec).unwrap();
+            vec
         }
 
         pub fn from_bytes(data: &[u8]) -> Self {
-            serde_cbor::from_slice(data).unwrap()
+            ciborium::de::from_reader(data).unwrap()
         }
     }
 


### PR DESCRIPTION
This PR proposes to move to `ciborium` because `serde_cbor` is deprecated.

The performance seems somewhat comparable.