### PR TITLE
perf: Use `ctz` instruction and `Lsb0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,9 @@ harness = false
 name = "real_data_bench"
 harness = false
 
+[[bench]]
+name = "bitmask_bench"
+harness = false
+
 [profile.bench]
 debug = true

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mmap_payload_storage::bitmask::{Bitmask, REGION_SIZE_BLOCKS};
 use rand::{thread_rng, Rng};
 
-pub fn bench_calculate_gaps(c: &mut Criterion) {
+pub fn bench_bitmask_ops(c: &mut Criterion) {
     let distr = rand::distributions::Standard;
     let rng = thread_rng();
     let random_bitvec = rng
@@ -30,5 +30,5 @@ pub fn bench_calculate_gaps(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_calculate_gaps);
+criterion_group!(benches, bench_bitmask_ops);
 criterion_main!(benches);

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -19,6 +19,15 @@ pub fn bench_calculate_gaps(c: &mut Criterion) {
             Bitmask::calculate_gaps(black_box(bitslice))
         })
     });
+    
+    c.bench_function("find_available_blocks", |b| {
+        let mut rng = thread_rng();
+        b.iter(|| {
+            let bitslice = bitslice_iter.next().unwrap();
+            let num_blocks = rng.gen_range(1..10);
+            Bitmask::find_available_blocks_in_slice(black_box(bitslice), num_blocks, |_| (0,0))
+        })
+    });
 }
 
 criterion_group!(benches, bench_calculate_gaps);

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -19,13 +19,13 @@ pub fn bench_bitmask_ops(c: &mut Criterion) {
             Bitmask::calculate_gaps(black_box(bitslice))
         })
     });
-    
+
     c.bench_function("find_available_blocks", |b| {
         let mut rng = thread_rng();
         b.iter(|| {
             let bitslice = bitslice_iter.next().unwrap();
             let num_blocks = rng.gen_range(1..10);
-            Bitmask::find_available_blocks_in_slice(black_box(bitslice), num_blocks, |_| (0,0))
+            Bitmask::find_available_blocks_in_slice(black_box(bitslice), num_blocks, |_| (0, 0))
         })
     });
 }

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -1,0 +1,25 @@
+use bitvec::vec::BitVec;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use mmap_payload_storage::bitmask::{Bitmask, REGION_SIZE_BLOCKS};
+use rand::{thread_rng, Rng};
+
+pub fn bench_calculate_gaps(c: &mut Criterion) {
+    let distr = rand::distributions::Standard;
+    let rng = thread_rng();
+    let random_bitvec = rng
+        .sample_iter::<bool, _>(distr)
+        .take(1000 * REGION_SIZE_BLOCKS as usize)
+        .collect::<BitVec>();
+
+    let mut bitslice_iter = random_bitvec.windows(REGION_SIZE_BLOCKS as usize).cycle();
+
+    c.bench_function("calculate_gaps", |b| {
+        b.iter(|| {
+            let bitslice = bitslice_iter.next().unwrap();
+            Bitmask::calculate_gaps(black_box(bitslice))
+        })
+    });
+}
+
+criterion_group!(benches, bench_calculate_gaps);
+criterion_main!(benches);

--- a/rocksdb-benches/src/main.rs
+++ b/rocksdb-benches/src/main.rs
@@ -15,7 +15,7 @@ fn default_opts(workload: &mut Workload) -> &mut Workload {
 }
 
 fn main() {
-    for n in [1, 4, 16].into_iter() {
+    for n in [1].into_iter() {
         println!("------------ {} thread(s) -------------", n);
         // Read heavy
         println!("**read_heavy** with prefill_fraction 0.95");

--- a/src/bitmask.rs
+++ b/src/bitmask.rs
@@ -500,7 +500,7 @@ impl Bitmask {
 
 #[cfg(test)]
 mod tests {
-    use bitvec::{bits, order::Msb0, vec::BitVec};
+    use bitvec::{bits, vec::BitVec};
 
     use crate::{bitmask::REGION_SIZE_BLOCKS, payload_storage::BLOCK_SIZE_BYTES};
 
@@ -568,7 +568,7 @@ mod tests {
             1, 1, 1, 1, 1, 1
         ];
 
-        let mut bitvec = BitVec::<usize, Msb0>::new();
+        let mut bitvec = BitVec::<usize, Lsb0>::new();
         bitvec.extend_from_bitslice(bits);
 
         assert_eq!(bitvec.len(), 64);
@@ -576,9 +576,9 @@ mod tests {
         let raw = bitvec.as_raw_slice();
         assert_eq!(raw.len() as u32, 64 / usize::BITS);
 
-        assert_eq!(raw[0].leading_zeros(), 4);
-        assert_eq!(raw[0].trailing_zeros(), 0);
-        assert_eq!((raw[0] << 1).leading_zeros(), 3)
+        assert_eq!(raw[0].trailing_zeros(), 4);
+        assert_eq!(raw[0].leading_zeros(), 0);
+        assert_eq!((raw[0] >> 1).trailing_zeros(), 3)
     }
     // TODO: proptest!!! (for find_available blocks)
 }

--- a/src/bitmask.rs
+++ b/src/bitmask.rs
@@ -267,8 +267,8 @@ impl Bitmask {
                 // cover the case of large number of blocks
                 if window_size >= 3 {
                     // check that the middle regions are empty
-                    for i in 1..window_size - 1 {
-                        if gaps[i].max as usize != REGION_SIZE_BLOCKS {
+                    for gap in gaps.iter().take(window_size - 1).skip(1) {
+                        if gap.max as usize != REGION_SIZE_BLOCKS {
                             return None;
                         }
                     }
@@ -361,7 +361,7 @@ impl Bitmask {
         let mut num_shifts = 0;
         // Iterate over the integers that compose the bitvec. So that we can perform bitwise operations.
         const BITS_IN_CHUNK: u32 = usize::BITS;
-        for (chunk_idx, &mut mut chunk) in bitvec.as_raw_mut_slice().into_iter().enumerate() {
+        for (chunk_idx, &mut mut chunk) in bitvec.as_raw_mut_slice().iter_mut().enumerate() {
             while chunk != 0 {
                 let num_zeros = chunk.trailing_zeros();
                 current_size += num_zeros;
@@ -434,11 +434,7 @@ impl Bitmask {
     }
 
     pub fn calculate_gaps(region: &BitSlice) -> Gaps {
-        debug_assert_eq!(
-            region.len(),
-            REGION_SIZE_BLOCKS as usize,
-            "Unexpected region size"
-        );
+        debug_assert_eq!(region.len(), REGION_SIZE_BLOCKS, "Unexpected region size");
         // copy slice into bitvec
         // TODO: make shifting and counting leading/trailing depend on the native Lsb0 or Msb0
         // (or what we set the bitslice to be)
@@ -449,7 +445,7 @@ impl Bitmask {
         // Iterate over the integers that compose the bitvec. So that we can perform bitwise operations.
         const BITS_IN_CHUNK: u16 = usize::BITS as u16;
         let mut num_shifts = 0;
-        for &mut mut chunk in bitvec.as_raw_mut_slice().into_iter() {
+        for &mut mut chunk in bitvec.as_raw_mut_slice().iter_mut() {
             while chunk != 0 {
                 // count consecutive zeros
                 let num_zeros = chunk.trailing_zeros() as u16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod bitmask;
+pub mod bitmask;
 pub mod fixtures;
 mod page;
 pub mod payload;


### PR DESCRIPTION
This PR improves perfomance of `calculate_gaps` and `find_available_blocks` even further by leveraging two things:

- faster creation of bitvec from bitslice. And explicitly choosing `Lsb0` (At least for my system... We could check with a different bitslice and different bit order)
- replacing loops of shifting a single bit at a time with using `count trailing zeros` instruction and shifting a larger amount of bits at once.


Now the "bottleneck" (it takes a little more than half of the operation time) would be the bitvec creation, but I don't see how we could avoid that and still be able to process the slice as its raw representation.

## Results
Before:
```
------------ 1 thread(s) -------------
**read_heavy** with prefill_fraction 0.95
PayloadStorage:
1572864 operations across 1 thread(s) in 1.601686375s; time/op = 1.018µs
RocksDB:
1572864 operations across 1 thread(s) in 905.831959ms; time/op = 575ns

**insert_heavy** with prefill_fraction 0.0
PayloadStorage:
1572864 operations across 1 thread(s) in 10.361096084s; time/op = 6.587µs
RocksDB:
1572864 operations across 1 thread(s) in 3.359631417s; time/op = 2.135µs

**update_heavy** with prefill_fraction 0.5
PayloadStorage:
1572864 operations across 1 thread(s) in 8.492014708s; time/op = 5.399µs
RocksDB:
1572864 operations across 1 thread(s) in 1.965619542s; time/op = 1.249µs
```

After:
```
------------ 1 thread(s) -------------
**read_heavy** with prefill_fraction 0.95
PayloadStorage:
1572864 operations across 1 thread(s) in 946.685667ms; time/op = 601ns
RocksDB:
1572864 operations across 1 thread(s) in 954.203375ms; time/op = 606ns

**insert_heavy** with prefill_fraction 0.0
PayloadStorage:
1572864 operations across 1 thread(s) in 2.717830917s; time/op = 1.727µs
RocksDB:
1572864 operations across 1 thread(s) in 3.521887125s; time/op = 2.239µs

**update_heavy** with prefill_fraction 0.5
PayloadStorage:
1572864 operations across 1 thread(s) in 1.952809875s; time/op = 1.241µs
RocksDB:
1572864 operations across 1 thread(s) in 1.97704325s; time/op = 1.256µs
```