### PR TITLE
Do not allocate extra bitvec for bitslice

### DIFF
--- a/src/bitmask.rs
+++ b/src/bitmask.rs
@@ -355,13 +355,23 @@ impl Bitmask {
     where
         F: FnOnce(u32) -> (PageId, BlockOffset),
     {
-        let mut bitvec = BitVec::<usize, Lsb0>::from_bitslice(bitslice);
+        // Get raw memory region
+        let (head, raw_region, tail) = bitslice
+            .domain()
+            .region()
+            .expect("Regions cover more than one usize");
+
+        // We expect the regions to not use partial usizes
+        debug_assert!(head.is_none());
+        debug_assert!(tail.is_none());
+
         let mut current_size: u32 = 0;
         let mut current_start: u32 = 0;
         let mut num_shifts = 0;
         // Iterate over the integers that compose the bitvec. So that we can perform bitwise operations.
         const BITS_IN_CHUNK: u32 = usize::BITS;
-        for (chunk_idx, &mut mut chunk) in bitvec.as_raw_mut_slice().iter_mut().enumerate() {
+        for (chunk_idx, chunk) in raw_region.iter().enumerate() {
+            let mut chunk = *chunk;
             while chunk != 0 {
                 let num_zeros = chunk.trailing_zeros();
                 current_size += num_zeros;
@@ -440,15 +450,14 @@ impl Bitmask {
             .domain()
             .region()
             .expect("Region covers more than one usize");
-        
+
         // We expect the region to not use partial usizes
         debug_assert!(head.is_none());
         debug_assert!(tail.is_none());
 
+        // Iterate over the integers that compose the bitslice. So that we can perform bitwise operations.
         let mut max = 0;
         let mut current = 0;
-
-        // Iterate over the integers that compose the bitslice. So that we can perform bitwise operations.
         const BITS_IN_CHUNK: u16 = usize::BITS as u16;
         let mut num_shifts = 0;
         for chunk in raw_region {
@@ -493,8 +502,17 @@ impl Bitmask {
             leading = max;
             trailing = max;
         } else {
-            leading = region.leading_zeros() as u16;
-            trailing = region.trailing_zeros() as u16;
+            leading = raw_region
+                .iter()
+                .take_while_inclusive(|chunk| chunk == &&0)
+                .map(|chunk| chunk.trailing_zeros())
+                .sum::<u32>() as u16;
+            trailing = raw_region
+                .iter()
+                .rev()
+                .take_while_inclusive(|chunk| chunk == &&0)
+                .map(|chunk| chunk.leading_zeros())
+                .sum::<u32>() as u16;
         }
 
         Gaps::new(leading, trailing, max)


### PR DESCRIPTION
Turns out, I hadn't read the `BitVec` documentation thoroughly and it IS indeed possible to read the bitslice directly.

Even now that we are copying each integer chunk when processing, not creating a new bitvec on the fly gives the following improvement:

```
Finished `bench` profile [optimized + debuginfo] target(s) in 2.17s
     Running benches/bitmask_bench.rs (target/release/deps/bitmask_bench-45d5d69951807178)
Gnuplot not found, using plotters backend
calculate_gaps          time:   [3.2224 µs 3.2324 µs 3.2428 µs]
                        change: [-10.470% -10.032% -9.6058%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

find_available_blocks   time:   [119.89 ns 120.66 ns 121.47 ns]
                        change: [-60.048% -59.627% -59.256%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
```

### New numbers against RocksDB.

Before:
```
**read_heavy** with prefill_fraction 0.95
PayloadStorage:
1572864 operations across 1 thread(s) in 909.604709ms; time/op = 578ns
RocksDB:
1572864 operations across 1 thread(s) in 875.479625ms; time/op = 556ns

**insert_heavy** with prefill_fraction 0.0
PayloadStorage:
1572864 operations across 1 thread(s) in 2.756195458s; time/op = 1.752µs
RocksDB:
1572864 operations across 1 thread(s) in 3.359350125s; time/op = 2.135µs

**update_heavy** with prefill_fraction 0.5
PayloadStorage:
1572864 operations across 1 thread(s) in 2.001515917s; time/op = 1.272µs
RocksDB:
1572864 operations across 1 thread(s) in 1.950734792s; time/op = 1.24µs
```

After:
```
**read_heavy** with prefill_fraction 0.95
PayloadStorage:
1572864 operations across 1 thread(s) in 894.836625ms; time/op = 568ns
RocksDB:
1572864 operations across 1 thread(s) in 891.638333ms; time/op = 566ns

**insert_heavy** with prefill_fraction 0.0
PayloadStorage:
1572864 operations across 1 thread(s) in 1.89236525s; time/op = 1.203µs
RocksDB:
1572864 operations across 1 thread(s) in 3.440077292s; time/op = 2.187µs

**update_heavy** with prefill_fraction 0.5
PayloadStorage:
1572864 operations across 1 thread(s) in 1.601730208s; time/op = 1.018µs
RocksDB:
1572864 operations across 1 thread(s) in 2.04536125s; time/op = 1.3µs
```