### PR TITLE
Use serde_json serializer

### DIFF
--- a/src/payload.rs
+++ b/src/payload.rs
@@ -14,13 +14,11 @@ impl Default for Payload {
 
 impl Value for Payload {
     fn to_bytes(&self) -> Vec<u8> {
-        let mut vec = Vec::new();
-        ciborium::ser::into_writer(self, &mut vec).unwrap();
-        vec
+        serde_json::to_vec(self).unwrap()
     }
 
     fn from_bytes(data: &[u8]) -> Self {
-        ciborium::de::from_reader(data).unwrap()
+        serde_json::from_slice(data).unwrap()
     }
 }
 


### PR DESCRIPTION
`serde_json` serialization is faster than `ciborium`, so let's use this one instead

Before:
```
------------ 1 thread(s) -------------
**read_heavy** with prefill_fraction 0.95
ValueStorage:
1572864 operations across 1 thread(s) in 903.186041ms; time/op = 574ns

**insert_heavy** with prefill_fraction 0.0
ValueStorage:
1572864 operations across 1 thread(s) in 1.950499667s; time/op = 1.24µs

**update_heavy** with prefill_fraction 0.5
ValueStorage:
1572864 operations across 1 thread(s) in 1.766226833s; time/op = 1.122µs
```


After:
```
------------ 1 thread(s) -------------
**read_heavy** with prefill_fraction 0.95
ValueStorage:
1572864 operations across 1 thread(s) in 767.020958ms; time/op = 487ns

**insert_heavy** with prefill_fraction 0.0
ValueStorage:
1572864 operations across 1 thread(s) in 1.811419625s; time/op = 1.151µs

**update_heavy** with prefill_fraction 0.5
ValueStorage:
1572864 operations across 1 thread(s) in 1.68138975s; time/op = 1.068µs
```