### PR TITLE
perf: skip shifting on bitslices

### DIFF
--- a/rocksdb-benches/src/fixture.rs
+++ b/rocksdb-benches/src/fixture.rs
@@ -39,7 +39,7 @@ impl<S> StorageProxy<S> {
 }
 
 impl<S: SequentialCollectionHandle> StorageProxy<S> {
-    const FLUSH_INTERVAL: u32 = 1000;
+    const FLUSH_INTERVAL: u32 = 10000;
 
     fn maybe_flush(&mut self) {
         if self.write_count >= Self::FLUSH_INTERVAL {

--- a/src/bitmask/mod.rs
+++ b/src/bitmask/mod.rs
@@ -361,7 +361,7 @@ impl Bitmask {
         // Iterate over the integers that compose the bitslice. So that we can perform bitwise operations.
         let mut max = 0;
         let mut current = 0;
-        const BITS_IN_CHUNK: u16 = usize::BITS as u16;
+        const BITS_IN_CHUNK: u32 = usize::BITS;
         let mut num_shifts = 0;
         // In reverse, because we expect the regions to be filled start to end.
         // So starting from the end should give us bigger `max` earlier.
@@ -382,8 +382,8 @@ impl Bitmask {
             }
 
             // At least one non-zero bit
-            let leading = chunk.leading_zeros() as u16;
-            let trailing = chunk.trailing_zeros() as u16;
+            let leading = chunk.leading_zeros();
+            let trailing = chunk.trailing_zeros();
 
             let max_possible_middle_gap = (BITS_IN_CHUNK - leading - trailing).saturating_sub(2);
 
@@ -398,7 +398,7 @@ impl Bitmask {
             // Otherwise, look for the actual maximum in the chunk
             while chunk != 0 {
                 // count consecutive zeros
-                let num_zeros = chunk.leading_zeros() as u16;
+                let num_zeros = chunk.leading_zeros();
                 current += num_zeros;
                 max = max.max(current);
                 current = 0;
@@ -408,7 +408,7 @@ impl Bitmask {
                 num_shifts += num_zeros;
 
                 // skip consecutive ones
-                let num_ones = chunk.leading_ones() as u16;
+                let num_ones = chunk.leading_ones();
                 if num_ones < BITS_IN_CHUNK {
                     chunk <<= num_ones;
                 } else {
@@ -428,7 +428,7 @@ impl Bitmask {
 
         let leading;
         let trailing;
-        if max == REGION_SIZE_BLOCKS as u16 {
+        if max == REGION_SIZE_BLOCKS as u32 {
             leading = max;
             trailing = max;
         } else {
@@ -436,16 +436,16 @@ impl Bitmask {
                 .iter()
                 .take_while_inclusive(|chunk| chunk == &&0)
                 .map(|chunk| chunk.trailing_zeros())
-                .sum::<u32>() as u16;
+                .sum::<u32>();
             trailing = raw_region
                 .iter()
                 .rev()
                 .take_while_inclusive(|chunk| chunk == &&0)
                 .map(|chunk| chunk.leading_zeros())
-                .sum::<u32>() as u16;
+                .sum::<u32>();
         }
 
-        RegionGaps::new(leading, trailing, max)
+        RegionGaps::new(leading as u16, trailing as u16, max as u16)
     }
 }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -79,7 +79,7 @@ impl Page {
         let value_start = block_offset as usize * BLOCK_SIZE_BYTES;
 
         let mmap_len = self.mmap.len();
-        
+
         assert!(value_start < mmap_len);
 
         let value_end = value_start + length as usize;


### PR DESCRIPTION
Some bitslice manipulation can be skipped once we know we are looking for a bigger gap.

Before:
```
**read_heavy** with prefill_fraction 0.95
ValueStorage:
1572864 operations across 1 thread(s) in 667.539917ms; time/op = 424ns

**insert_heavy** with prefill_fraction 0.0
ValueStorage:
1572864 operations across 1 thread(s) in 1.480921333s; time/op = 941ns

**update_heavy** with prefill_fraction 0.5
ValueStorage:
1572864 operations across 1 thread(s) in 1.196354125s; time/op = 760ns
```

After:
```
**read_heavy** with prefill_fraction 0.95
ValueStorage:
1572864 operations across 1 thread(s) in 645.705792ms; time/op = 410ns

**insert_heavy** with prefill_fraction 0.0
ValueStorage:
1572864 operations across 1 thread(s) in 1.289140709s; time/op = 819ns

**update_heavy** with prefill_fraction 0.5
ValueStorage:
1572864 operations across 1 thread(s) in 1.099946458s; time/op = 699ns
```
