### PR TITLE
Make storage configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ rand = "0.8.5"
 bitvec = "1.0.1"
 thiserror = "1.0.65"
 itertools = "0.13.0"
+atomicwrites = "0.4.4"
+nix = "0.29.0"
+bincode = "1.3.3"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -1,5 +1,5 @@
 use bitvec::vec::BitVec;
-use blob_store::bitmask::{Bitmask, DEFAULT_REGION_SIZE_BLOCKS};
+use blob_store::{bitmask::Bitmask, config::DEFAULT_REGION_SIZE_BLOCKS};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -1,5 +1,5 @@
 use bitvec::vec::BitVec;
-use blob_store::bitmask::{Bitmask, REGION_SIZE_BLOCKS};
+use blob_store::bitmask::{Bitmask, DEFAULT_REGION_SIZE_BLOCKS};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 

--- a/benches/bitmask_bench.rs
+++ b/benches/bitmask_bench.rs
@@ -8,15 +8,15 @@ pub fn bench_bitmask_ops(c: &mut Criterion) {
     let rng = thread_rng();
     let random_bitvec = rng
         .sample_iter::<bool, _>(distr)
-        .take(1000 * REGION_SIZE_BLOCKS)
+        .take(1000 * DEFAULT_REGION_SIZE_BLOCKS)
         .collect::<BitVec>();
 
-    let mut bitslice_iter = random_bitvec.windows(REGION_SIZE_BLOCKS).cycle();
+    let mut bitslice_iter = random_bitvec.windows(DEFAULT_REGION_SIZE_BLOCKS).cycle();
 
     c.bench_function("calculate_gaps", |b| {
         b.iter(|| {
             let bitslice = bitslice_iter.next().unwrap();
-            Bitmask::calculate_gaps(black_box(bitslice))
+            Bitmask::calculate_gaps(black_box(bitslice), DEFAULT_REGION_SIZE_BLOCKS)
         })
     });
 

--- a/src/bitmask/gaps.rs
+++ b/src/bitmask/gaps.rs
@@ -333,7 +333,7 @@ mod tests {
             num_blocks in 1..=(DEFAULT_REGION_SIZE_BLOCKS as u32 * 3)
         ) {
             let temp_dir = tempdir().unwrap();
-            let config = StorageOptions::default().into();
+            let config = StorageOptions::default().try_into().unwrap();
             let bitmask_gaps = BitmaskGaps::create(temp_dir.path(), gaps.clone().into_iter(), config);
 
             let bitvec = regions_gaps_to_bitvec(&gaps, DEFAULT_REGION_SIZE_BLOCKS);
@@ -382,7 +382,7 @@ mod tests {
 
         // Create RegionGaps and write gaps
         {
-            let config = StorageOptions::default().into();
+            let config = StorageOptions::default().try_into().unwrap();
             let region_gaps = BitmaskGaps::create(dir_path, gaps.clone().into_iter(), config);
             assert_eq!(region_gaps.len(), gaps.len());
             for (i, gap) in gaps.iter().enumerate() {
@@ -392,7 +392,7 @@ mod tests {
 
         // Reopen RegionGaps and verify gaps
         {
-            let config = StorageOptions::default().into();
+            let config = StorageOptions::default().try_into().unwrap();
             let region_gaps = BitmaskGaps::open(dir_path, config);
             assert_eq!(region_gaps.len(), gaps.len());
             for (i, gap) in gaps.iter().enumerate() {
@@ -407,7 +407,7 @@ mod tests {
         ];
 
         {
-            let config = StorageOptions::default().into();
+            let config = StorageOptions::default().try_into().unwrap();
             let mut region_gaps = BitmaskGaps::open(dir_path, config);
             region_gaps.extend(more_gaps.clone().into_iter());
             assert_eq!(region_gaps.len(), gaps.len() + more_gaps.len());
@@ -418,7 +418,7 @@ mod tests {
 
         // Reopen RegionGaps and verify all gaps
         {
-            let config = StorageOptions::default().into();
+            let config = StorageOptions::default().try_into().unwrap();
             let region_gaps = BitmaskGaps::open(dir_path, config);
             assert_eq!(region_gaps.len(), gaps.len() + more_gaps.len());
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {

--- a/src/bitmask/gaps.rs
+++ b/src/bitmask/gaps.rs
@@ -251,7 +251,7 @@ impl BitmaskGaps {
 
 #[cfg(test)]
 mod tests {
-    use crate::{bitmask::DEFAULT_REGION_SIZE_BLOCKS, config::StorageOptions};
+    use crate::config::{StorageOptions, DEFAULT_REGION_SIZE_BLOCKS};
 
     use super::*;
 

--- a/src/bitmask/mod.rs
+++ b/src/bitmask/mod.rs
@@ -480,6 +480,7 @@ mod tests {
     fn test_length_for_page() {
         let config = &StorageOptions {
             page_size_bytes: Some(8192),
+            region_size_blocks: Some(1),
             ..Default::default()
         }
         .try_into()

--- a/src/bitmask/mod.rs
+++ b/src/bitmask/mod.rs
@@ -448,12 +448,20 @@ impl Bitmask {
                 .sum::<u32>();
         }
 
-        RegionGaps::new(
-            leading as u16,
-            trailing as u16,
-            max as u16,
-            region_size_blocks as u16,
-        )
+        #[cfg(debug_assertions)]
+        {
+            RegionGaps::new(
+                leading as u16,
+                trailing as u16,
+                max as u16,
+                region_size_blocks as u16,
+            )
+        }
+
+        #[cfg(not(debug_assertions))]
+        {
+            RegionGaps::new(leading as u16, trailing as u16, max as u16)
+        }
     }
 }
 

--- a/src/bitmask/mod.rs
+++ b/src/bitmask/mod.rs
@@ -482,7 +482,8 @@ mod tests {
             page_size_bytes: Some(8192),
             ..Default::default()
         }
-        .into();
+        .try_into()
+        .unwrap();
         assert_eq!(super::Bitmask::length_for_page(config), 8);
     }
 
@@ -499,7 +500,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut bitmask = super::Bitmask::create(dir.path(), options.into());
+        let mut bitmask = super::Bitmask::create(dir.path(), options.try_into().unwrap());
         bitmask.cover_new_page();
 
         assert_eq!(bitmask.bitslice.len() as u32, blocks_per_page * 2);

--- a/src/bitmask/mod.rs
+++ b/src/bitmask/mod.rs
@@ -14,7 +14,6 @@ use crate::utils_copied::mmap_ops::{create_and_ensure_length, open_write_mmap};
 use crate::utils_copied::mmap_type::{self, MmapBitSlice};
 
 const BITMASK_NAME: &str = "bitmask.dat";
-pub const DEFAULT_REGION_SIZE_BLOCKS: usize = 8_192;
 
 type RegionId = u32;
 
@@ -472,9 +471,7 @@ mod tests {
     use proptest::prelude::*;
     use rand::thread_rng;
 
-    use crate::bitmask::DEFAULT_REGION_SIZE_BLOCKS;
-    use crate::blob_store::DEFAULT_BLOCK_SIZE_BYTES;
-    use crate::config::StorageOptions;
+    use crate::config::{StorageOptions, DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS};
 
     #[test]
     fn test_length_for_page() {

--- a/src/blob_store.rs
+++ b/src/blob_store.rs
@@ -497,11 +497,13 @@ mod tests {
         assert_eq!(storage.pages.len(), 1);
         assert_eq!(storage.tracker.read().mapping_len(), 1);
         let files = storage.files();
-        assert_eq!(files.len(), 4, "Expected 4 files, got {:?}", files);
+        assert_eq!(files.len(), 5, "Expected 5 files, got {:?}", files);
         assert_eq!(files[0].file_name().unwrap(), "tracker.dat");
         assert_eq!(files[1].file_name().unwrap(), "page_0.dat");
         assert_eq!(files[2].file_name().unwrap(), "bitmask.dat");
         assert_eq!(files[3].file_name().unwrap(), "gaps.dat");
+        assert_eq!(files[4].file_name().unwrap(), "config.json");
+        
     }
 
     #[test]

--- a/src/blob_store.rs
+++ b/src/blob_store.rs
@@ -9,13 +9,6 @@ use lz4_flex::compress_prepend_size;
 use parking_lot::RwLock;
 use std::path::PathBuf;
 
-/// Expect JSON values to have roughly 3–5 fields with mostly small values.
-/// For 1M values, this would require 128MB of memory.
-pub const DEFAULT_BLOCK_SIZE_BYTES: usize = 128;
-
-/// Default page size used when not specified
-pub const DEFAULT_PAGE_SIZE_BYTES: usize = 32 * 1024 * 1024; // 32MB
-
 const CONFIG_FILENAME: &str = "config.json";
 
 /// Storage for values of type `V`.
@@ -433,8 +426,10 @@ impl<V> Drop for BlobStore<V> {
 mod tests {
     use super::*;
 
-    use crate::bitmask::DEFAULT_REGION_SIZE_BLOCKS;
     use crate::blob::Blob;
+    use crate::config::{
+        DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS,
+    };
     use crate::fixtures::{empty_storage, empty_storage_sized, random_payload, HM_FIELDS};
     use crate::payload::Payload;
     use rand::{distributions::Uniform, prelude::Distribution, seq::SliceRandom, Rng};

--- a/src/blob_store.rs
+++ b/src/blob_store.rs
@@ -1,5 +1,6 @@
 use crate::bitmask::Bitmask;
 use crate::blob::Blob;
+use crate::config::{StorageConfig, StorageOptions};
 use crate::page::Page;
 use crate::tracker::{BlockOffset, PageId, PointOffset, Tracker, ValuePointer};
 use crate::utils_copied::mmap_type;
@@ -10,22 +11,24 @@ use std::path::PathBuf;
 
 /// Expect JSON values to have roughly 3–5 fields with mostly small values.
 /// For 1M values, this would require 128MB of memory.
-pub const BLOCK_SIZE_BYTES: usize = 128;
+pub const DEFAULT_BLOCK_SIZE_BYTES: usize = 128;
 
 /// Default page size used when not specified
-pub const PAGE_SIZE_BYTES: usize = 32 * 1024 * 1024; // 32MB
+pub const DEFAULT_PAGE_SIZE_BYTES: usize = 32 * 1024 * 1024; // 32MB
+
+const CONFIG_FILENAME: &str = "config.json";
 
 /// Storage for values of type `V`.
 ///
 /// Assumes sequential IDs to the values (0, 1, 2, 3, ...)
 #[derive(Debug)]
 pub struct BlobStore<V> {
+    /// Configuration of the storage.
+    pub(super) config: StorageConfig,
     /// Holds mapping from `PointOffset` -> `ValuePointer`
     ///
     /// Stored in a separate file
     tracker: RwLock<Tracker>,
-    /// Page size in bytes when creating new pages, normally 32MB
-    pub(super) new_page_size: usize,
     /// Mapping from page_id -> mmap page
     pub(super) pages: Vec<Page>,
     /// Bitmask to represent which "blocks" of data in the pages are used and which are free.
@@ -73,23 +76,29 @@ impl<V: Blob> BlobStore<V> {
     ///
     /// `base_path` is the directory where the storage files will be stored.
     /// It should exist already.
-    pub fn new(base_path: PathBuf, page_size: Option<usize>) -> Self {
+    pub fn new(base_path: PathBuf, options: StorageOptions) -> Self {
         assert!(base_path.exists(), "Base path does not exist");
         assert!(base_path.is_dir(), "Base path is not a directory");
-        let page_size = page_size.unwrap_or(PAGE_SIZE_BYTES);
+        let config = StorageConfig::from(options);
+
+        // write config to disk
+        let config_path = base_path.join(CONFIG_FILENAME);
+        let file = std::fs::File::create(&config_path).unwrap();
+        serde_json::to_writer_pretty(file, &config).unwrap();
+
         let mut storage = Self {
             tracker: RwLock::new(Tracker::new(&base_path, None)),
-            new_page_size: page_size,
             pages: Default::default(),
-            bitmask: RwLock::new(Bitmask::create(&base_path, page_size)),
+            bitmask: RwLock::new(Bitmask::create(&base_path, config.clone())),
             base_path,
+            config,
             _value_type: std::marker::PhantomData,
         };
 
         // create first page to be covered by the bitmask
         let new_page_id = storage.next_page_id();
         let path = storage.page_path(new_page_id);
-        let page = Page::new(&path, storage.new_page_size);
+        let page = Page::new(&path, storage.config.page_size_bytes);
         storage.pages.push(page);
 
         storage
@@ -97,19 +106,22 @@ impl<V: Blob> BlobStore<V> {
 
     /// Open an existing storage at the given path
     /// Returns None if the storage does not exist
-    pub fn open(path: PathBuf, new_page_size: Option<usize>) -> Option<Self> {
-        let new_page_size = new_page_size.unwrap_or(PAGE_SIZE_BYTES);
+    pub fn open(path: PathBuf) -> Option<Self> {
+        // read config file
+        let config_path = path.join(CONFIG_FILENAME);
+        let config_file = std::fs::File::open(&config_path).ok()?;
+        let config: StorageConfig = serde_json::from_reader(config_file).ok()?;
 
         let page_tracker = Tracker::open(&path)?;
 
-        let bitmask = Bitmask::open(&path, new_page_size)?;
+        let bitmask = Bitmask::open(&path, config.clone())?;
 
         let num_pages = bitmask.infer_num_pages();
 
         // load pages
         let mut storage = Self {
             tracker: RwLock::new(page_tracker),
-            new_page_size,
+            config,
             pages: Default::default(),
             bitmask: RwLock::new(bitmask),
             base_path: path.clone(),
@@ -140,7 +152,8 @@ impl<V: Blob> BlobStore<V> {
 
         for page_id in start_page_id.. {
             let page = &self.pages[page_id as usize];
-            let (raw, unread_bytes) = page.read_value(block_offset, length);
+            let (raw, unread_bytes) =
+                page.read_value(block_offset, length, self.config.block_size_bytes);
             raw_sections.extend(raw);
 
             if unread_bytes == 0 {
@@ -176,7 +189,7 @@ impl<V: Blob> BlobStore<V> {
     fn create_new_page(&mut self) -> u32 {
         let new_page_id = self.next_page_id();
         let path = self.page_path(new_page_id);
-        let page = Page::new(&path, self.new_page_size);
+        let page = Page::new(&path, self.config.page_size_bytes);
         self.pages.push(page);
 
         self.bitmask.write().cover_new_page();
@@ -204,7 +217,8 @@ impl<V: Blob> BlobStore<V> {
 
         let missing_blocks = num_blocks.saturating_sub(trailing_free_blocks) as usize;
 
-        let num_pages = (missing_blocks * BLOCK_SIZE_BYTES).div_ceil(self.new_page_size);
+        let num_pages =
+            (missing_blocks * self.config.block_size_bytes).div_ceil(self.config.page_size_bytes);
         for _ in 0..num_pages {
             self.create_new_page();
         }
@@ -232,7 +246,8 @@ impl<V: Blob> BlobStore<V> {
             let page = &mut self.pages[page_id as usize];
 
             let range = (value_size - unwritten_tail)..;
-            unwritten_tail = page.write_value(block_offset, &value[range]);
+            unwritten_tail =
+                page.write_value(block_offset, &value[range], self.config.block_size_bytes);
 
             if unwritten_tail == 0 {
                 break;
@@ -298,7 +313,7 @@ impl<V: Blob> BlobStore<V> {
         let comp_value = Self::compress(&value_bytes);
         let value_size = comp_value.len();
 
-        let required_blocks = Self::blocks_for_value(value_size);
+        let required_blocks = Self::blocks_for_value(value_size, self.config.block_size_bytes);
         let (start_page_id, block_offset) = self.find_or_create_available_blocks(required_blocks);
 
         // insert into a new cell, considering that it can span more than one page
@@ -372,8 +387,8 @@ impl<V: Blob> BlobStore<V> {
 
 impl<V> BlobStore<V> {
     /// The number of blocks needed for a given value bytes size
-    fn blocks_for_value(value_size: usize) -> u32 {
-        value_size.div_ceil(BLOCK_SIZE_BYTES).try_into().unwrap()
+    fn blocks_for_value(value_size: usize, block_size: usize) -> u32 {
+        value_size.div_ceil(block_size).try_into().unwrap()
     }
 
     /// Flush all mmaps and pending updates to disk
@@ -392,7 +407,7 @@ impl<V> BlobStore<V> {
                 guard.mark_blocks(
                     pointer.page_id,
                     pointer.block_offset,
-                    Self::blocks_for_value(pointer.length as usize),
+                    Self::blocks_for_value(pointer.length as usize, self.config.block_size_bytes),
                     false,
                 );
             }
@@ -413,12 +428,10 @@ impl<V> Drop for BlobStore<V> {
 mod tests {
     use super::*;
 
-    use crate::{
-        bitmask::REGION_SIZE_BLOCKS,
-        blob::Blob,
-        fixtures::{empty_storage, empty_storage_sized, random_payload, HM_FIELDS},
-        payload::Payload,
-    };
+    use crate::bitmask::DEFAULT_REGION_SIZE_BLOCKS;
+    use crate::blob::Blob;
+    use crate::fixtures::{empty_storage, empty_storage_sized, random_payload, HM_FIELDS};
+    use crate::payload::Payload;
     use rand::{distributions::Uniform, prelude::Distribution, seq::SliceRandom, Rng};
     use rstest::rstest;
     use tempfile::Builder;
@@ -586,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_write_across_pages() {
-        let page_size = BLOCK_SIZE_BYTES * REGION_SIZE_BLOCKS;
+        let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
         let (_dir, mut storage) = empty_storage_sized(page_size);
 
         storage.create_new_page();
@@ -600,7 +613,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Let's write it near the end
-        let block_offset = REGION_SIZE_BLOCKS - 10;
+        let block_offset = DEFAULT_REGION_SIZE_BLOCKS - 10;
         storage.write_into_pages(&value, 0, block_offset as u32);
 
         let read_value = storage.read_from_pages(0, block_offset as u32, value_len as u32);
@@ -635,7 +648,9 @@ mod tests {
     }
 
     #[rstest]
-    fn test_behave_like_hashmap(#[values(1_048_576, 2_097_152, PAGE_SIZE_BYTES)] page_size: usize) {
+    fn test_behave_like_hashmap(
+        #[values(1_048_576, 2_097_152, DEFAULT_PAGE_SIZE_BYTES)] page_size: usize,
+    ) {
         use std::collections::HashMap;
 
         let (dir, mut storage) = empty_storage_sized(page_size);
@@ -686,8 +701,7 @@ mod tests {
         drop(storage);
 
         // reopen storage
-        let storage =
-            BlobStore::<Payload>::open(dir.path().to_path_buf(), Some(page_size)).unwrap();
+        let storage = BlobStore::<Payload>::open(dir.path().to_path_buf()).unwrap();
 
         // asset same length
         assert_eq!(storage.tracker.read().mapping_len(), model_hashmap.len());
@@ -735,8 +749,8 @@ mod tests {
         {
             // the fitting page should be 64MB, so we should still have about 14MB of free space
             let free_blocks = storage.bitmask.read().free_blocks_for_page(1);
-            let min_expected = 1024 * 1024 * 13 / BLOCK_SIZE_BYTES;
-            let max_expected = 1024 * 1024 * 15 / BLOCK_SIZE_BYTES;
+            let min_expected = 1024 * 1024 * 13 / DEFAULT_BLOCK_SIZE_BYTES;
+            let max_expected = 1024 * 1024 * 15 / DEFAULT_BLOCK_SIZE_BYTES;
             assert!((min_expected..max_expected).contains(&free_blocks));
         }
 
@@ -762,8 +776,7 @@ mod tests {
         );
 
         {
-            let mut storage = BlobStore::new(path.clone(), None);
-
+            let mut storage = BlobStore::new(path.clone(), Default::default());
             storage.put_value(0, &payload);
             assert_eq!(storage.pages.len(), 1);
 
@@ -780,7 +793,7 @@ mod tests {
         }
 
         // reopen storage
-        let storage = BlobStore::<Payload>::open(path.clone(), None).unwrap();
+        let storage = BlobStore::<Payload>::open(path.clone()).unwrap();
         assert_eq!(storage.pages.len(), 1);
 
         let stored_payload = storage.get_value(0);
@@ -862,7 +875,7 @@ mod tests {
         drop(storage);
 
         // reopen storage
-        let mut storage = BlobStore::open(dir.path().to_path_buf(), None).unwrap();
+        let mut storage = BlobStore::open(dir.path().to_path_buf()).unwrap();
         assert_eq!(point_offset, EXPECTED_LEN as u32 * 2);
         assert_eq!(storage.pages.len(), 4);
         assert_eq!(storage.tracker.read().mapping_len(), EXPECTED_LEN * 2);

--- a/src/blob_store.rs
+++ b/src/blob_store.rs
@@ -503,7 +503,6 @@ mod tests {
         assert_eq!(files[2].file_name().unwrap(), "bitmask.dat");
         assert_eq!(files[3].file_name().unwrap(), "gaps.dat");
         assert_eq!(files[4].file_name().unwrap(), "config.json");
-        
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::bitmask::DEFAULT_REGION_SIZE_BLOCKS;
-use crate::value_storage::{DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES};
+use crate::blob_store::{DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES};
 
+/// Configuration options for the storage
 #[derive(Debug, Default)]
 pub struct StorageOptions {
     /// Size of a page in bytes. Must be a multiple of (`block_size` * `region_size`).
@@ -39,18 +40,43 @@ pub(crate) struct StorageConfig {
     pub region_size_blocks: usize,
 }
 
-impl From<StorageOptions> for StorageConfig {
-    fn from(options: StorageOptions) -> Self {
+impl TryFrom<StorageOptions> for StorageConfig {
+    type Error = &'static str;
+
+    fn try_from(options: StorageOptions) -> Result<Self, Self::Error> {
         let page_size_bytes = options.page_size_bytes.unwrap_or(DEFAULT_PAGE_SIZE_BYTES);
         let block_size_bytes = options.block_size_bytes.unwrap_or(DEFAULT_BLOCK_SIZE_BYTES);
         let region_size_blocks = options
             .region_size_blocks
             .map(|x| x as usize)
             .unwrap_or(DEFAULT_REGION_SIZE_BLOCKS);
-        Self {
+
+        if block_size_bytes == 0 {
+            return Err("Block size must be greater than 0");
+        }
+
+        if region_size_blocks == 0 {
+            return Err("Region size must be greater than 0");
+        }
+
+        if page_size_bytes == 0 {
+            return Err("Page size must be greater than 0");
+        }
+
+        let region_size_bytes = block_size_bytes * region_size_blocks;
+
+        if page_size_bytes < region_size_bytes {
+            return Err("Page size must be greater than or equal to (block size * region size)");
+        }
+
+        if page_size_bytes % region_size_bytes != 0 {
+            return Err("Page size must be a multiple of (block size * region size)");
+        }
+
+        Ok(Self {
             page_size_bytes,
             block_size_bytes,
             region_size_blocks,
-        }
+        })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use crate::blob_store::{DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES};
 /// Configuration options for the storage
 #[derive(Debug, Default)]
 pub struct StorageOptions {
-    /// Size of a page in bytes. Must be a multiple of (`block_size` * `region_size`).
+    /// Size of a page in bytes. Must be a multiple of (`block_size_bytes` * `region_size_blocks`).
     ///
     /// Default is 32MB
     pub page_size_bytes: Option<usize>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+use crate::bitmask::DEFAULT_REGION_SIZE_BLOCKS;
+use crate::value_storage::{DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES};
+
+#[derive(Debug, Default)]
+pub struct StorageOptions {
+    /// Size of a page in bytes. Must be a multiple of (`block_size` * `region_size`).
+    ///
+    /// Default is 32MB
+    pub page_size_bytes: Option<usize>,
+
+    /// Size of a block in bytes
+    ///
+    /// Default is 128 bytes
+    pub block_size_bytes: Option<usize>,
+
+    /// Size of a region in blocks
+    ///
+    /// Default is 8192 blocks
+    pub region_size_blocks: Option<u16>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StorageConfig {
+    /// Size of a page in bytes
+    ///
+    /// Default is 32MB
+    pub page_size_bytes: usize,
+
+    /// Size of a block in bytes
+    ///
+    /// Default is 128 bytes
+    pub block_size_bytes: usize,
+
+    /// Size of a region in blocks
+    ///
+    /// Default is 8192 blocks
+    pub region_size_blocks: usize,
+}
+
+impl From<StorageOptions> for StorageConfig {
+    fn from(options: StorageOptions) -> Self {
+        let page_size_bytes = options.page_size_bytes.unwrap_or(DEFAULT_PAGE_SIZE_BYTES);
+        let block_size_bytes = options.block_size_bytes.unwrap_or(DEFAULT_BLOCK_SIZE_BYTES);
+        let region_size_blocks = options
+            .region_size_blocks
+            .map(|x| x as usize)
+            .unwrap_or(DEFAULT_REGION_SIZE_BLOCKS);
+        Self {
+            page_size_bytes,
+            block_size_bytes,
+            region_size_blocks,
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::bitmask::DEFAULT_REGION_SIZE_BLOCKS;
-use crate::blob_store::{DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_PAGE_SIZE_BYTES};
+/// Expect JSON values to have roughly 3–5 fields with mostly small values.
+/// For 1M values, this would require 128MB of memory.
+pub const DEFAULT_BLOCK_SIZE_BYTES: usize = 128;
+
+/// Default page size used when not specified
+pub const DEFAULT_PAGE_SIZE_BYTES: usize = 32 * 1024 * 1024; // 32MB
+
+pub const DEFAULT_REGION_SIZE_BLOCKS: usize = 8_192;
 
 /// Configuration options for the storage
 #[derive(Debug, Default)]

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -1,3 +1,4 @@
+use crate::config::StorageOptions;
 use crate::payload::Payload;
 use crate::BlobStore;
 use rand::distributions::{Distribution, Uniform};
@@ -7,14 +8,18 @@ use tempfile::{Builder, TempDir};
 /// Create an empty storage with the default configuration
 pub fn empty_storage() -> (TempDir, BlobStore<Payload>) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
-    let storage = BlobStore::new(dir.path().to_path_buf(), None);
+    let storage = BlobStore::new(dir.path().to_path_buf(), Default::default());
     (dir, storage)
 }
 
 /// Create an empty storage with a specific page size
 pub fn empty_storage_sized(page_size: usize) -> (TempDir, BlobStore<Payload>) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
-    let storage = BlobStore::new(dir.path().to_path_buf(), Some(page_size));
+    let options = StorageOptions {
+        page_size_bytes: Some(page_size),
+        ..Default::default()
+    };
+    let storage = BlobStore::new(dir.path().to_path_buf(), options);
     (dir, storage)
 }
 

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -8,7 +8,7 @@ use tempfile::{Builder, TempDir};
 /// Create an empty storage with the default configuration
 pub fn empty_storage() -> (TempDir, BlobStore<Payload>) {
     let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
-    let storage = BlobStore::new(dir.path().to_path_buf(), Default::default());
+    let storage = BlobStore::new(dir.path().to_path_buf(), Default::default()).unwrap();
     (dir, storage)
 }
 
@@ -19,7 +19,7 @@ pub fn empty_storage_sized(page_size: usize) -> (TempDir, BlobStore<Payload>) {
         page_size_bytes: Some(page_size),
         ..Default::default()
     };
-    let storage = BlobStore::new(dir.path().to_path_buf(), options);
+    let storage = BlobStore::new(dir.path().to_path_buf(), options).unwrap();
     (dir, storage)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod bitmask;
 pub mod blob;
 mod blob_store;
-mod config;
+pub mod config;
 pub mod fixtures;
 mod page;
 pub mod payload;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bitmask;
 pub mod blob;
 mod blob_store;
+mod config;
 pub mod fixtures;
 mod page;
 pub mod payload;

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,4 +1,3 @@
-use crate::blob_store::BLOCK_SIZE_BYTES;
 use crate::tracker::BlockOffset;
 use crate::utils_copied::madvise::{Advice, AdviceSetting};
 use crate::utils_copied::mmap_ops::{create_and_ensure_length, open_write_mmap};
@@ -44,11 +43,16 @@ impl Page {
     /// # Corruption
     ///
     /// If the block_offset and length of the value are already taken, this function will still overwrite the data.
-    pub fn write_value(&mut self, block_offset: u32, value: &[u8]) -> usize {
+    pub fn write_value(
+        &mut self,
+        block_offset: u32,
+        value: &[u8],
+        block_size_bytes: usize,
+    ) -> usize {
         // The size of the data cell containing the value
         let value_size = value.len();
 
-        let value_start = block_offset as usize * BLOCK_SIZE_BYTES;
+        let value_start = block_offset as usize * block_size_bytes;
 
         let value_end = value_start + value_size;
         // only write what fits in the page
@@ -75,8 +79,13 @@ impl Page {
     ///
     /// When the `block_offset` starts after the page ends
     ///
-    pub fn read_value(&self, block_offset: BlockOffset, length: u32) -> (&[u8], usize) {
-        let value_start = block_offset as usize * BLOCK_SIZE_BYTES;
+    pub fn read_value(
+        &self,
+        block_offset: BlockOffset,
+        length: u32,
+        block_size_bytes: usize,
+    ) -> (&[u8], usize) {
+        let value_start = block_offset as usize * block_size_bytes;
 
         let mmap_len = self.mmap.len();
 

--- a/src/utils_copied/file_operations.rs
+++ b/src/utils_copied/file_operations.rs
@@ -1,0 +1,109 @@
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter};
+use std::path::Path;
+use std::result;
+
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+pub fn atomic_save_bin<T: Serialize>(path: &Path, object: &T) -> Result<()> {
+    let af = AtomicFile::new(path, OverwriteBehavior::AllowOverwrite);
+    af.write(|f| bincode::serialize_into(BufWriter::new(f), object))?;
+    Ok(())
+}
+
+pub fn atomic_save_json<T: Serialize>(path: &Path, object: &T) -> Result<()> {
+    let af = AtomicFile::new(path, OverwriteBehavior::AllowOverwrite);
+    af.write(|f| serde_json::to_writer(BufWriter::new(f), object))?;
+    Ok(())
+}
+
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    Ok(serde_json::from_reader(BufReader::new(File::open(path)?))?)
+}
+
+pub fn read_bin<T: DeserializeOwned>(path: &Path) -> Result<T> {
+    Ok(bincode::deserialize_from(BufReader::new(File::open(
+        path,
+    )?))?)
+}
+
+/// Advise the operating system that the file is no longer needed to be in the page cache.
+pub fn advise_dontneed(path: &Path) -> Result<()> {
+    _ = path;
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_os = "wasi",
+        target_env = "uclibc",
+        target_os = "freebsd",
+    ))] // https://github.com/nix-rust/nix/blob/v0.29.0/src/fcntl.rs#L35-L42
+    {
+        nix::fcntl::posix_fadvise(
+            std::os::fd::AsRawFd::as_raw_fd(&File::open(path)?),
+            0,
+            0,
+            nix::fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED,
+        )?;
+    }
+
+    Ok(())
+}
+
+pub type FileOperationResult<T> = Result<T>;
+pub type FileStorageError = Error;
+
+pub type Result<T, E = Error> = result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Io(#[from] io::Error),
+
+    #[cfg(unix)]
+    #[error("{0}")]
+    Errno(#[from] nix::errno::Errno),
+
+    #[error("{0}")]
+    Bincode(#[from] bincode::ErrorKind),
+
+    #[error("{0}")]
+    SerdeJson(#[from] serde_json::Error),
+
+    #[error("{0}")]
+    Generic(String),
+}
+
+impl Error {
+    pub fn generic(msg: impl Into<String>) -> Self {
+        Self::Generic(msg.into())
+    }
+}
+
+impl<E> From<atomicwrites::Error<E>> for Error
+where
+    Self: From<E>,
+{
+    fn from(err: atomicwrites::Error<E>) -> Self {
+        match err {
+            atomicwrites::Error::Internal(err) => err.into(),
+            atomicwrites::Error::User(err) => err.into(),
+        }
+    }
+}
+
+impl From<bincode::Error> for Error {
+    fn from(err: bincode::Error) -> Self {
+        Self::Bincode(*err)
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, err.to_string())
+    }
+}

--- a/src/utils_copied/file_operations.rs
+++ b/src/utils_copied/file_operations.rs
@@ -29,31 +29,6 @@ pub fn read_bin<T: DeserializeOwned>(path: &Path) -> Result<T> {
     )?))?)
 }
 
-/// Advise the operating system that the file is no longer needed to be in the page cache.
-pub fn advise_dontneed(path: &Path) -> Result<()> {
-    _ = path;
-
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "emscripten",
-        target_os = "fuchsia",
-        target_os = "wasi",
-        target_env = "uclibc",
-        target_os = "freebsd",
-    ))] // https://github.com/nix-rust/nix/blob/v0.29.0/src/fcntl.rs#L35-L42
-    {
-        nix::fcntl::posix_fadvise(
-            std::os::fd::AsRawFd::as_raw_fd(&File::open(path)?),
-            0,
-            0,
-            nix::fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED,
-        )?;
-    }
-
-    Ok(())
-}
-
 pub type FileOperationResult<T> = Result<T>;
 pub type FileStorageError = Error;
 

--- a/src/utils_copied/mod.rs
+++ b/src/utils_copied/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod file_operations;
 pub mod madvise;
 pub mod mmap_ops;
 pub mod mmap_type;


### PR DESCRIPTION
Introduces `StorageOptions` and `StorageConfig` to depend less on constants, and be able to configure different sizes of:
- block size
- region size
- page size