### PR TITLE
Propagate errors instead of unwrapping

### DIFF
--- a/benches/random_data_bench.rs
+++ b/benches/random_data_bench.rs
@@ -12,7 +12,7 @@ pub fn random_data_bench(c: &mut Criterion) {
             || random_payload(&mut rng, 2),
             |payload| {
                 for i in 0..PAYLOAD_COUNT {
-                    storage.put_value(i, payload);
+                    storage.put_value(i, payload).unwrap();
                 }
             },
             BatchSize::SmallInput,

--- a/benches/real_data_bench.rs
+++ b/benches/real_data_bench.rs
@@ -22,7 +22,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
                         Value::String(record.get(i).unwrap().to_string()),
                     );
                 }
-                storage.put_value(point_offset, &payload);
+                storage.put_value(point_offset, &payload).unwrap();
                 point_offset += 1;
             }
             assert_eq!(point_offset, expected_point_count);

--- a/src/blob_store.rs
+++ b/src/blob_store.rs
@@ -124,7 +124,7 @@ impl<V: Blob> BlobStore<V> {
         let mut storage = Self {
             tracker: RwLock::new(page_tracker),
             config,
-            pages: Default::default(),
+            pages: Vec::with_capacity(num_pages),
             bitmask: RwLock::new(bitmask),
             base_path: path.clone(),
             _value_type: std::marker::PhantomData,

--- a/src/page.rs
+++ b/src/page.rs
@@ -17,22 +17,24 @@ impl Page {
     }
 
     /// Create a new page at the given path
-    pub fn new(path: &Path, size: usize) -> Page {
-        create_and_ensure_length(path, size).unwrap();
-        let mmap = open_write_mmap(path, AdviceSetting::from(Advice::Normal), false).unwrap();
+    pub fn new(path: &Path, size: usize) -> Result<Page, String> {
+        create_and_ensure_length(path, size).map_err(|err| err.to_string())?;
+        let mmap = open_write_mmap(path, AdviceSetting::from(Advice::Normal), false)
+            .map_err(|err| err.to_string())?;
         let path = path.to_path_buf();
-        Page { path, mmap }
+        Ok(Page { path, mmap })
     }
 
     /// Open an existing page at the given path
     /// If the file does not exist, return None
-    pub fn open(path: &Path) -> Option<Page> {
+    pub fn open(path: &Path) -> Result<Page, String> {
         if !path.exists() {
-            return None;
+            return Err(format!("Page file does not exist: {}", path.display()));
         }
-        let mmap = open_write_mmap(path, AdviceSetting::from(Advice::Normal), false).unwrap();
+        let mmap = open_write_mmap(path, AdviceSetting::from(Advice::Normal), false)
+            .map_err(|err| err.to_string())?;
         let path = path.to_path_buf();
-        Some(Page { path, mmap })
+        Ok(Page { path, mmap })
     }
 
     /// Write a value into the page

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -116,15 +116,16 @@ impl Tracker {
 
     /// Open an existing PageTracker at the given path
     /// If the file does not exist, return None
-    pub fn open(path: &Path) -> Option<Self> {
+    pub fn open(path: &Path) -> Result<Self, String> {
         let path = Self::tracker_file_name(path);
         if !path.exists() {
-            return None;
+            return Err(format!("Tracker file does not exist: {}", path.display()));
         }
-        let mmap = open_write_mmap(&path, AdviceSetting::from(TRACKER_MEM_ADVICE), false).unwrap();
+        let mmap = open_write_mmap(&path, AdviceSetting::from(TRACKER_MEM_ADVICE), false)
+            .map_err(|err| err.to_string())?;
         let header: &TrackerHeader = transmute_from_u8(&mmap[0..size_of::<TrackerHeader>()]);
         let pending_updates = HashMap::new();
-        Some(Self {
+        Ok(Self {
             next_pointer_offset: header.next_pointer_offset,
             path,
             header: header.clone(),


### PR DESCRIPTION
Audits the places where we were unwrapping, and instead now it propagates errors